### PR TITLE
Add OpenMP pragmas to WaveformAligner and MilkdropNoise

### DIFF
--- a/src/libprojectM/Audio/WaveformAligner.cpp
+++ b/src/libprojectM/Audio/WaveformAligner.cpp
@@ -4,6 +4,10 @@
 #include <cmath>
 #include <iterator>
 
+#ifdef PRJM_ENABLE_OPENMP
+#include <omp.h>
+#endif
+
 namespace libprojectM {
 namespace Audio {
 
@@ -143,6 +147,9 @@ int WaveformAligner::CalculateOffset(std::vector<WaveformBuffer>& newWaveformMip
 
             // Perform the cross-correlation. Note that we shift the new waveform but not the old
             // one because we're looking for the offset between them that produces the lowest error.
+#ifdef PRJM_ENABLE_OPENMP
+#pragma omp parallel for reduction(+:errorSum) schedule(static)
+#endif
             for (uint32_t i = m_firstNonzeroWeights[octave]; i <= m_lastNonzeroWeights[octave]; i++)
             {
                 errorSum += std::abs((newWaveformMips[octave][i + sample] - m_oldWaveformMips[octave][i]) * m_aligmentWeights[octave][i]);

--- a/src/libprojectM/Renderer/CMakeLists.txt
+++ b/src/libprojectM/Renderer/CMakeLists.txt
@@ -99,6 +99,11 @@ if(PROJECTM_FILESYSTEM_USE_BOOST)
     )
 endif()
 
+if(ENABLE_OPENMP AND OpenMP_CXX_FOUND)
+    target_link_libraries(Renderer PUBLIC OpenMP::OpenMP_CXX)
+    target_compile_definitions(Renderer PUBLIC PRJM_ENABLE_OPENMP)
+endif()
+
 set_target_properties(Renderer PROPERTIES
         FOLDER libprojectM
         )

--- a/src/libprojectM/Renderer/MilkdropNoise.cpp
+++ b/src/libprojectM/Renderer/MilkdropNoise.cpp
@@ -7,6 +7,10 @@
 #include <memory>
 #include <random>
 
+#ifdef PRJM_ENABLE_OPENMP
+#include <omp.h>
+#endif
+
 namespace libprojectM {
 namespace Renderer {
 
@@ -90,6 +94,9 @@ auto MilkdropNoise::generate2D(int size, int zoomFactor) -> std::vector<uint32_t
         dst = textureData.data();
 
         // first go ACROSS, blending cubically on X, but only on the main lines.
+#ifdef PRJM_ENABLE_OPENMP
+#pragma omp parallel for schedule(static)
+#endif
         for (auto y = 0; y < size; y += zoomFactor)
         {
             for (auto x = 0; x < size; x++)
@@ -113,6 +120,9 @@ auto MilkdropNoise::generate2D(int size, int zoomFactor) -> std::vector<uint32_t
         }
 
         // next go down, doing cubic interp along Y, on every line.
+#ifdef PRJM_ENABLE_OPENMP
+#pragma omp parallel for schedule(static)
+#endif
         for (auto x = 0; x < size; x++)
         {
             for (auto y = 0; y < size; y++)
@@ -180,6 +190,9 @@ auto MilkdropNoise::generate3D(int size, int zoomFactor) -> std::vector<uint32_t
     {
         // first go ACROSS, blending cubically on X, but only on the main lines.
         auto dst = textureData.data();
+#ifdef PRJM_ENABLE_OPENMP
+#pragma omp parallel for schedule(static)
+#endif
         for (auto z = 0; z < size; z += zoomFactor)
         {
             for (auto y = 0; y < size; y += zoomFactor)
@@ -206,6 +219,9 @@ auto MilkdropNoise::generate3D(int size, int zoomFactor) -> std::vector<uint32_t
         }
 
         // next go down, doing cubic interp along Y, on the main slices.
+#ifdef PRJM_ENABLE_OPENMP
+#pragma omp parallel for schedule(static)
+#endif
         for (auto z = 0; z < size; z += zoomFactor)
         {
             for (auto x = 0; x < size; x++)
@@ -232,6 +248,9 @@ auto MilkdropNoise::generate3D(int size, int zoomFactor) -> std::vector<uint32_t
         }
 
         // next go through, doing cubic interp along Z, everywhere.
+#ifdef PRJM_ENABLE_OPENMP
+#pragma omp parallel for schedule(static)
+#endif
         for (auto x = 0; x < size; x++)
         {
             for (auto y = 0; y < size; y++)


### PR DESCRIPTION
- WaveformAligner::CalculateOffset(): parallelize innermost cross-correlation error-sum loop with reduction(+:errorSum), matching the existing pattern in Loudness.cpp; runs every frame during waveform alignment

- MilkdropNoise::generate2D(): parallelize both cubic-interpolation smoothing passes (X-pass over rows, Y-pass over columns); each outer-loop iteration writes to distinct pixels, up to 256 independent iterations each

- MilkdropNoise::generate3D(): parallelize all three smoothing passes (X-pass over z-slices, Y-pass over z-slices, Z-pass over x-columns); independent writes per iteration on 32x32x32 voxel data

- Renderer/CMakeLists.txt: add conditional OpenMP linkage for the Renderer OBJECT library so PRJM_ENABLE_OPENMP and OpenMP::OpenMP_CXX propagate to MilkdropNoise.cpp at compile time

All new pragmas follow the existing #ifdef PRJM_ENABLE_OPENMP guard pattern.

https://claude.ai/code/session_01APUQUn3JosH8WgVd8QwojW