### PR TITLE
Second-wave quality pass: HDR pipeline fix, OMP, sRGB, dither, C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(BUILD_DOCS "Build documentation" OFF)
 option(ENABLE_OPENMP "Enable OpenMP parallelization for performance-critical sections" OFF)
 option(ENABLE_HDR_RENDERING "Enable 16-bit float (GL_RGBA16F) framebuffer for HDR rendering with Reinhard tone-mapping" OFF)
 option(ENABLE_HDR_P3 "Enable Display-P3 wide-gamut output after sRGB tone-mapping (requires ENABLE_HDR_RENDERING)" OFF)
+option(ENABLE_SRGB_FRAMEBUFFER "Enable GL_SRGB8_ALPHA8 framebuffer with hardware sRGB encode/decode (SDR path only, incompatible with ENABLE_HDR_RENDERING)" OFF)
 
 # Enable vcpkg manifest features according to the build options set
 if(ENABLE_SYSTEM_GLM)
@@ -156,7 +157,7 @@ if(ENABLE_EMSCRIPTEN)
             )
 
     add_link_options(
-            "SHELL:-std=c++17 -O3 -rtlib=compiler-rt-mt -mtune=wasm32 -s SHARED_MEMORY=1 -s WASM_WORKERS=1 -pthread "
+            "SHELL:-std=c++20 -O3 -rtlib=compiler-rt-mt -mtune=wasm32 -s SHARED_MEMORY=1 -s WASM_WORKERS=1 -pthread "
             "SHELL:-s MIN_WEBGL_VERSION=2 "
             "SHELL:-s MAX_WEBGL_VERSION=2 "
             "SHELL:-s USE_WEBGL2=1 -s FULL_ES2=0 -s FULL_ES3=1 -s GL_POOL_TEMP_BUFFERS=0 -s GL_MAX_TEMP_BUFFER_SIZE=33177600 -s GL_TRACK_ERRORS=0 "

--- a/src/libprojectM/Audio/MilkdropFFT.hpp
+++ b/src/libprojectM/Audio/MilkdropFFT.hpp
@@ -108,7 +108,7 @@ public:
      * This is twice the value of samplesOut passed to Init().
      * @return The number of frequency samples calculated.
      */
-    auto NumFrequencies() const -> size_t
+    auto NumFrequencies() const noexcept -> size_t
     {
         return m_numFrequencies;
     };

--- a/src/libprojectM/CMakeLists.txt
+++ b/src/libprojectM/CMakeLists.txt
@@ -58,6 +58,10 @@ if(ENABLE_HDR_P3 AND ENABLE_HDR_RENDERING)
     target_compile_definitions(projectM_main PUBLIC PROJECTM_HDR_P3=1)
 endif()
 
+if(ENABLE_SRGB_FRAMEBUFFER AND NOT ENABLE_HDR_RENDERING)
+    target_compile_definitions(projectM_main PUBLIC PROJECTM_SRGB_FRAMEBUFFER=1)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     target_link_libraries(projectM_main
             PUBLIC

--- a/src/libprojectM/MilkdropPreset/BlurTexture.cpp
+++ b/src/libprojectM/MilkdropPreset/BlurTexture.cpp
@@ -18,7 +18,11 @@ BlurTexture::BlurTexture()
     : m_blurMesh(Renderer::VertexBufferUsage::StaticDraw, false, true)
     , m_blurSampler(std::make_shared<Renderer::Sampler>(GL_CLAMP_TO_EDGE, GL_LINEAR))
 {
+#ifdef PROJECTM_HDR_RENDERING
+    m_blurFramebuffer.CreateColorAttachment(0, 0, GL_RGBA16F, GL_RGBA, GL_HALF_FLOAT);
+#else
     m_blurFramebuffer.CreateColorAttachment(0, 0);
+#endif
 
     // Initialize blur mesh with a single fullscreen quad.
     m_blurMesh.SetRenderPrimitiveType(Renderer::Mesh::PrimitiveType::TriangleStrip);
@@ -370,7 +374,11 @@ void BlurTexture::AllocateTextures(const Renderer::Texture& sourceTexture)
         }
 
         // This will automatically replace any old texture.
+#ifdef PROJECTM_HDR_RENDERING
+        m_blurTextures[i] = std::make_shared<Renderer::Texture>(textureName, GL_TEXTURE_2D, width2, height2, 0, GL_RGBA16F, GL_RGBA, GL_HALF_FLOAT, false);
+#else
         m_blurTextures[i] = std::make_shared<Renderer::Texture>(textureName, width2, height2, false);
+#endif
     }
 
     m_sourceTextureWidth = sourceTexture.Width();

--- a/src/libprojectM/MilkdropPreset/FinalComposite.cpp
+++ b/src/libprojectM/MilkdropPreset/FinalComposite.cpp
@@ -351,6 +351,12 @@ void FinalComposite::ApplyHueShaderColors(const PresetState& presetState)
     auto& vertices = m_compositeMesh.Vertices();
     auto& colors = m_compositeMesh.Colors();
 
+    // All (gridX, gridY) pairs are independent: vertexIndex = gridX + gridY*width is unique,
+    // reads are from vertices[] (read-only here) and shade[] (read-only), writes only to
+    // colors[vertexIndex]. collapse(2) distributes 32×64 = 2048 iterations across threads.
+#ifdef PRJM_ENABLE_OPENMP
+#pragma omp parallel for collapse(2) schedule(static)
+#endif
     for (int gridY = 0; gridY < compositeGridHeight; gridY++)
     {
         for (int gridX = 0; gridX < compositeGridWidth; gridX++)

--- a/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
+++ b/src/libprojectM/MilkdropPreset/MilkdropShader.cpp
@@ -425,8 +425,21 @@ void PS(float4 _vDiffuse : COLOR,
     found = program.rfind('}');
     if (found != std::string::npos)
     {
-        program.replace(int(found), 1, "_return_value = float4(ret.xyz, 1.0);\n"
-                                       "}\n");
+#ifdef PROJECTM_HDR_RENDERING
+        // Composite shader: apply Reinhard tone-mapping + sRGB gamma encode at the final
+        // output stage. This is the correct place — the warp shader output stays linear so
+        // the feedback loop operates in linear light, and tone-mapping only runs once here.
+        if (m_type == ShaderType::CompositeShader)
+        {
+            program.replace(int(found), 1, "_return_value = float4(_prjm_hdr_out(ret.xyz), 1.0);\n"
+                                           "}\n");
+        }
+        else
+#endif
+        {
+            program.replace(int(found), 1, "_return_value = float4(ret.xyz, 1.0);\n"
+                                           "}\n");
+        }
     }
     else
     {
@@ -502,6 +515,35 @@ void PS(float4 _vDiffuse : COLOR,
                           "#define uv _uv.xy\n"
                           "#define uv_orig _uv.xy\n"
                           "#define hue_shader _vDiffuse.xyz\n");
+
+#ifdef PROJECTM_HDR_RENDERING
+        // Inject HDR tone-mapping helpers into the composite shader (HLSL syntax).
+        // _prjm_hdr_out is called on ret.xyz just before the output assignment,
+        // converting linear light to tone-mapped, sRGB-gamma-encoded display output.
+        // The transpiler converts saturate→clamp, lerp→mix, mul→matrix multiply, etc.
+        fullSource.append(
+            "float3 _prjm_reinhard(float3 c) {\n"
+            "    float lum = dot(c, float3(0.2126, 0.7152, 0.0722));\n"
+            "    return c * (lum / ((1.0 + lum) * max(lum, 0.0001)));\n"
+            "}\n"
+            "float3 _prjm_linear_to_srgb(float3 c) {\n"
+            "    float3 lo = c * 12.92;\n"
+            "    float3 hi = 1.055 * pow(saturate(c), 1.0 / 2.4) - 0.055;\n"
+            "    return lerp(lo, hi, step(0.0031308, c));\n"
+            "}\n"
+            "float3 _prjm_hdr_out(float3 c) {\n"
+            "    c = _prjm_linear_to_srgb(_prjm_reinhard(c));\n"
+#ifdef PROJECTM_HDR_P3
+            // BT.709 → Display-P3 (D65) color matrix, row-major HLSL convention.
+            "    float3x3 _bt709_to_p3 = float3x3(\n"
+            "        0.8225, 0.1774, 0.0003,\n"
+            "        0.0331, 0.9669, 0.0003,\n"
+            "        0.0171, 0.0724, 0.9108);\n"
+            "    c = saturate(mul(_bt709_to_p3, c));\n"
+#endif
+            "    return c;\n"
+            "}\n");
+#endif
     }
 
     fullSource.append(program);

--- a/src/libprojectM/MilkdropPreset/Shaders/PresetWarpFragmentShaderGlsl330.frag
+++ b/src/libprojectM/MilkdropPreset/Shaders/PresetWarpFragmentShaderGlsl330.frag
@@ -7,10 +7,11 @@ uniform sampler2D texture_sampler;
 layout(location = 0) out vec4 color;
 layout(location = 1) out vec2 texCoords;
 
-// Triangular-PDF dither: two hash-based uniform noises summed give a triangular
-// distribution. Amplitude of 1/255 = 1 LSB in 8-bit, which whitens quantization
-// noise and eliminates banding in the temporal feedback loop.
-// Under HDR (16-bit float) this amplitude is scaled down to be negligible.
+// Triangular-PDF dither applied to the feedback texture write.
+// Whitens quantization noise in the 8-bit temporal loop (SDR) or is negligible
+// in float16 (HDR). Tone-mapping/gamma-encode is intentionally NOT done here —
+// the warp output feeds back into the next frame's texture sampler and must
+// remain in linear light so that decay/fade math is physically correct.
 float tpdDither(vec2 fc) {
     float r1 = fract(sin(dot(fc, vec2(12.9898, 78.233))) * 43758.5453);
     float r2 = fract(sin(dot(fc, vec2(93.989,  67.345))) * 12345.678);
@@ -21,47 +22,14 @@ float tpdDither(vec2 fc) {
 #endif
 }
 
-#ifdef PROJECTM_HDR_RENDERING
-// Reinhard luminance tone-mapping: maps unbounded HDR values into [0,1] while
-// preserving relative brightness. Operates on linear light before gamma encoding.
-vec3 reinhardTonemap(vec3 c) {
-    float lum = dot(c, vec3(0.2126, 0.7152, 0.0722));
-    float lumMapped = lum / (1.0 + lum);
-    return c * (lumMapped / max(lum, 0.0001));
-}
-
-// Piecewise sRGB gamma encode (IEC 61966-2-1).
-// Converts linear light to display-referred sRGB for SDR output.
-vec3 linearToSRGB(vec3 c) {
-    vec3 lo = c * 12.92;
-    vec3 hi = 1.055 * pow(clamp(c, 0.0, 1.0), vec3(1.0 / 2.4)) - 0.055;
-    return mix(lo, hi, step(0.0031308, c));
-}
-#endif
-
 void main() {
-    // Main image
+    // Sample previous frame with decay applied (decay = frag_COLOR.rgb)
     color = frag_COLOR * texture(texture_sampler, frag_TEXCOORD0.xy);
 
-#ifdef PROJECTM_HDR_RENDERING
-    // HDR path: tone-map from unbounded linear light → [0,1], then gamma-encode.
-    color.rgb = linearToSRGB(reinhardTonemap(color.rgb));
-
-#ifdef PROJECTM_HDR_P3
-    // BT.709 primaries → Display-P3 (D65 white point) color matrix.
-    // Applied after sRGB gamma encode so the display interprets the signal as P3.
-    // Source: ICC color science, column-major mat3 (GLSL convention).
-    const mat3 bt709_to_p3 = mat3(
-         0.8225,  0.0331,  0.0171,
-         0.1774,  0.9669,  0.0724,
-         0.0003,  0.0003,  0.9108);
-    color.rgb = clamp(bt709_to_p3 * color.rgb, 0.0, 1.0);
-#endif
-#endif
-
-    // Apply dither after tone-mapping, before quantization
+    // Dither before quantization; keeps values linear for the feedback loop
     color.rgb += tpdDither(gl_FragCoord.xy);
 
     // Motion vector grid u/v coords for the next frame
     texCoords = frag_TEXCOORD0.xy;
 }
+

--- a/src/libprojectM/Renderer/Framebuffer.cpp
+++ b/src/libprojectM/Renderer/Framebuffer.cpp
@@ -46,6 +46,10 @@ void Framebuffer::Bind(int framebufferIndex)
 
     glBindFramebuffer(GL_FRAMEBUFFER, m_framebufferIds.at(framebufferIndex));
 
+#if defined(PROJECTM_SRGB_FRAMEBUFFER) && !defined(USE_GLES)
+    glEnable(GL_FRAMEBUFFER_SRGB);
+#endif
+
     m_readFramebuffer = m_drawFramebuffer = framebufferIndex;
 }
 
@@ -75,6 +79,9 @@ void Framebuffer::BindDraw(int framebufferIndex)
 
 void Framebuffer::Unbind()
 {
+#if defined(PROJECTM_SRGB_FRAMEBUFFER) && !defined(USE_GLES)
+    glDisable(GL_FRAMEBUFFER_SRGB);
+#endif
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 }
 

--- a/src/libprojectM/Renderer/Shader.hpp
+++ b/src/libprojectM/Renderer/Shader.hpp
@@ -84,7 +84,7 @@ public:
      * @param validationMessage The error message if validation failed.
      * @return true if the shader program is valid and can run, false if it broken.
      */
-    bool Validate(std::string& validationMessage) const;
+    [[nodiscard]] bool Validate(std::string& validationMessage) const;
 
     /**
      * Binds the program into the current context.
@@ -182,7 +182,7 @@ public:
      * not properly initialized or the context not made current.
      * @return The parsed version, or {0,0} if the version could not be parsed.
      */
-    static auto GetShaderLanguageVersion() -> GlslVersion;
+    [[nodiscard]] static auto GetShaderLanguageVersion() -> GlslVersion;
 
 private:
     /**

--- a/src/libprojectM/Renderer/Texture.cpp
+++ b/src/libprojectM/Renderer/Texture.cpp
@@ -86,42 +86,42 @@ void Texture::Unbind(GLint slot) const
     glBindTexture(m_target, 0);
 }
 
-auto Texture::TextureID() const -> GLuint
+auto Texture::TextureID() const noexcept -> GLuint
 {
     return m_textureId;
 }
 
-auto Texture::Name() const -> const std::string&
+auto Texture::Name() const noexcept -> const std::string&
 {
     return m_name;
 }
 
-auto Texture::Type() const -> GLenum
+auto Texture::Type() const noexcept -> GLenum
 {
     return m_target;
 }
 
-auto Texture::Width() const -> int
+auto Texture::Width() const noexcept -> int
 {
     return m_width;
 }
 
-auto Texture::Height() const -> int
+auto Texture::Height() const noexcept -> int
 {
     return m_height;
 }
 
-auto Texture::Depth() const -> int
+auto Texture::Depth() const noexcept -> int
 {
     return m_depth;
 }
 
-auto Texture::IsUserTexture() const -> bool
+auto Texture::IsUserTexture() const noexcept -> bool
 {
     return m_isUserTexture;
 }
 
-auto Texture::Empty() const -> bool
+auto Texture::Empty() const noexcept -> bool
 {
     return m_textureId == 0;
 }

--- a/src/libprojectM/Renderer/Texture.hpp
+++ b/src/libprojectM/Renderer/Texture.hpp
@@ -105,49 +105,49 @@ public:
      * @brief Returns the OpenGL texture name/ID.
      * @return The OpenGL texture name/ID.
      */
-    auto TextureID() const -> GLuint;
+    auto TextureID() const noexcept -> GLuint;
 
     /**
      * @brief Returns the texture name, e.g. base filename.
      * @return The texture name, for referencing the texture in shader code etc.
      */
-    auto Name() const -> const std::string&;
+    auto Name() const noexcept -> const std::string&;
 
     /**
      * @brief Returns the OpenGL texture type.
      * @return The texture type, e.g. GL_TEXTURE_2D.
      */
-    auto Type() const -> GLenum;
+    auto Type() const noexcept -> GLenum;
 
     /**
      * @brief Returns the width of the texture image in pixels.
      * @return The width of the texture image in pixels.
      */
-    auto Width() const -> int;
+    auto Width() const noexcept -> int;
 
     /**
      * @brief Returns the height of the texture image in pixels.
      * @return The height of the texture image in pixels.
      */
-    auto Height() const -> int;
+    auto Height() const noexcept -> int;
 
     /**
      * @brief Returns the depth of the texture image in pixels.
      * @return The depth of the texture image in pixels.
      */
-    auto Depth() const -> int;
+    auto Depth() const noexcept -> int;
 
     /**
      * @brief Returns if the texture is user-defined, e.g. loaded from an image.
      * @return true if the texture is a user texture, false if it's an internally generated texture.
      */
-    auto IsUserTexture() const -> bool;
+    auto IsUserTexture() const noexcept -> bool;
 
     /**
      * @brief Returns true if the texture is empty/unallocated.
      * @return true if the texture is not yet allocated (e.g. the ID 0), false if the object contains a valid texture.
      */
-    auto Empty() const -> bool;
+    auto Empty() const noexcept -> bool;
 
     /**
      * @brief Uploads new image data for the texture.

--- a/src/libprojectM/Renderer/TextureAttachment.cpp
+++ b/src/libprojectM/Renderer/TextureAttachment.cpp
@@ -77,6 +77,10 @@ void TextureAttachment::ReplaceTexture(int width, int height)
                 internalFormat = GL_RGBA16F;
                 textureFormat  = GL_RGBA;
                 pixelFormat    = GL_HALF_FLOAT;
+#elif defined(PROJECTM_SRGB_FRAMEBUFFER)
+                internalFormat = GL_SRGB8_ALPHA8;
+                textureFormat  = GL_RGBA;
+                pixelFormat    = GL_UNSIGNED_BYTE;
 #else
                 internalFormat = GL_RGBA;
                 textureFormat  = GL_RGBA;

--- a/src/libprojectM/Renderer/TransitionShaders/TransitionShaderMainGlsl330.frag
+++ b/src/libprojectM/Renderer/TransitionShaders/TransitionShaderMainGlsl330.frag
@@ -1,4 +1,16 @@
 
+// Triangular-PDF dither for the transition blend output.
+// Whitens quantization noise at the final display write.
+float _prjm_tpd_dither(vec2 fc) {
+    float r1 = fract(sin(dot(fc, vec2(12.9898, 78.233))) * 43758.5453);
+    float r2 = fract(sin(dot(fc, vec2(93.989,  67.345))) * 12345.678);
+#ifdef PROJECTM_HDR_RENDERING
+    return (r1 + r2 - 1.0) * (1.0 / 65535.0);
+#else
+    return (r1 + r2 - 1.0) * (1.0 / 255.0);
+#endif
+}
+
 void main() {
     _prjm_transition_out = vec4(1.0, 1.0, 1.0, 1.0);
 
@@ -6,5 +18,5 @@ void main() {
 
     mainImage(_user_out_color, gl_FragCoord.xy);
 
-    _prjm_transition_out = vec4(_user_out_color.xyz, 1.0);
+    _prjm_transition_out = vec4(_user_out_color.xyz + _prjm_tpd_dither(gl_FragCoord.xy), 1.0);
 }


### PR DESCRIPTION
Phase A — HDR tone-mapping stage fix (correctness bug):
- PresetWarpFragmentShaderGlsl330.frag: remove Reinhard+sRGB from warp output; warp feeds back as next-frame texture so must stay linear. Keep TPDF dither (SDR 1/255, HDR 1/65535 amplitude).
- MilkdropShader.cpp: inject _prjm_reinhard / _prjm_linear_to_srgb / _prjm_hdr_out HLSL helpers into composite shader fullSource; apply _prjm_hdr_out(ret.xyz) at the closing-brace replacement for composite shaders when PROJECTM_HDR_RENDERING is defined. Optional BT.709→P3 gamut matrix when PROJECTM_HDR_P3 is also defined.

Phase B — OpenMP colour interpolation (FinalComposite):
- ApplyHueShaderColors: add #pragma omp parallel for collapse(2) schedule(static) before the 32×64 nested grid loop; all iterations write to unique colors[vertexIndex] with no cross-iteration conflict.

Phase C — Blur textures in GL_RGBA16F for HDR path:
- BlurTexture constructor: create blur FBO attachment as GL_RGBA16F / GL_HALF_FLOAT under PROJECTM_HDR_RENDERING.
- BlurTexture::AllocateTextures: create each m_blurTextures[i] with the 9-arg Texture constructor (GL_RGBA16F, GL_RGBA, GL_HALF_FLOAT) under HDR, keeping GL_RGB / GL_UNSIGNED_BYTE for SDR.

Phase D — Transition shader TPDF dither:
- TransitionShaderMainGlsl330.frag: add _prjm_tpd_dither() (same hash as warp shader) and apply to the final _prjm_transition_out write.

Phase E — Optional sRGB framebuffer (hardware gamma, SDR only):
- CMakeLists.txt: new option ENABLE_SRGB_FRAMEBUFFER (default OFF); mutually exclusive with ENABLE_HDR_RENDERING.
- src/libprojectM/CMakeLists.txt: emit PROJECTM_SRGB_FRAMEBUFFER=1 compile definition when option is ON and HDR is OFF.
- TextureAttachment.cpp: use GL_SRGB8_ALPHA8 / GL_UNSIGNED_BYTE when PROJECTM_SRGB_FRAMEBUFFER is defined (new #elif branch).
- Framebuffer.cpp: Bind() calls glEnable(GL_FRAMEBUFFER_SRGB); Unbind() calls glDisable; both guarded by !defined(USE_GLES) since GLES 3.0 applies sRGB automatically for GL_SRGB8_ALPHA8 attachments.

Phase F1 — Emscripten C++20:
- CMakeLists.txt add_link_options: -std=c++17 → -std=c++20 so the Emscripten link step matches the compile step and __cplusplus guards activate for std::span / [[likely]] in MilkdropFFT.cpp.

Phase F2+F3 — C++ quality:
- Shader.hpp: [[nodiscard]] on Validate() and GetShaderLanguageVersion().
- Texture.hpp / Texture.cpp: noexcept on all eight trivial const getters (TextureID, Name, Type, Width, Height, Depth, IsUserTexture, Empty).
- MilkdropFFT.hpp: noexcept on NumFrequencies().

https://claude.ai/code/session_01APUQUn3JosH8WgVd8QwojW