### PR TITLE
Fix missing GLES precision qualifiers in MilkdropStaticShaders

### DIFF
--- a/src/libprojectM/MilkdropPreset/MilkdropStaticShaders.cpp.in
+++ b/src/libprojectM/MilkdropPreset/MilkdropStaticShaders.cpp.in
@@ -16,7 +16,9 @@ MilkdropStaticShaders::MilkdropStaticShaders(bool useGLES)
     if (m_useGLES)
     {
         // If GLES is enabled, use the embedded specification language variant.
-        m_versionHeader = "#version 300 es";
+        // Include precision qualifiers — GLES 3.0 fragment shaders have no default
+        // float precision, so every shader that uses float/vec/mat types requires one.
+        m_versionHeader = "#version 300 es\n\nprecision highp float;\nprecision highp int;\nprecision highp sampler2D;\nprecision highp sampler3D;";
         m_GLSLGeneratorVersion = M4::GLSLGenerator::Version::Version_300_ES;
     }
     else

--- a/src/libprojectM/Renderer/TransitionShaderManager.cpp
+++ b/src/libprojectM/Renderer/TransitionShaderManager.cpp
@@ -30,7 +30,7 @@ auto TransitionShaderManager::CompileTransitionShader(const std::string& shaderB
 {
 #ifdef USE_GLES
     // GLES also requires a precision specifier for variables and 3D samplers
-    constexpr char versionHeader[] = "#version 300 es\n\nprecision mediump float;\nprecision mediump sampler3D;\n";
+    constexpr char versionHeader[] = "#version 300 es\n\nprecision highp float;\nprecision highp int;\nprecision highp sampler2D;\nprecision highp sampler3D;\n";
 #else
     constexpr char versionHeader[] = "#version 330\n\n";
 #endif


### PR DESCRIPTION
AddVersionHeader() for GLES only emitted "#version 300 es" with no precision specifiers. GLES 3.0 / WebGL 2.0 fragment shaders have no default float precision, so any shader with float/vec/mat declarations would fail to compile with "No precision specified for (float)".

Fix: embed the full precision block in m_versionHeader for GLES:
  precision highp float;
  precision highp int;
  precision highp sampler2D;
  precision highp sampler3D;

highp matches CopyTexture.cpp and MilkdropSprite.cpp. The warp and blur shaders do per-pixel math (UVs, convolution weights) where mediump is too coarse.

Also upgrade TransitionShaderManager's GLES version header from mediump to highp for consistency and add sampler2D precision (was missing).

https://claude.ai/code/session_01APUQUn3JosH8WgVd8QwojW