### PR TITLE
Fix random preset button timing and error handling

### DIFF
--- a/html/projectm-core.html
+++ b/html/projectm-core.html
@@ -193,6 +193,11 @@ document.getElementById("apiRandomPresetBtn").addEventListener('click', async fu
         const res = await fetch(`${apiBase}/api/presets/random?dir=any`);
         if (!res.ok) throw new Error('API error: ' + res.status);
         const data = await res.json();
+
+        if (!data.url || !data.filename || !data.dir) {
+            throw new Error('Invalid API response: missing url, filename, or dir');
+        }
+
         const milkRes = await fetch(data.url);
         if (!milkRes.ok) throw new Error('Failed to fetch milk: ' + milkRes.status);
         const buffer = await milkRes.arrayBuffer();
@@ -203,7 +208,10 @@ document.getElementById("apiRandomPresetBtn").addEventListener('click', async fu
         Module.loadPresetFile(vfsPath);
         console.log('Loaded API preset:', data.filename, 'from', data.dir);
     } catch (e) {
-        console.error('Failed to load API preset:', e);
+        console.error('Failed to load API preset, falling back to local preset:', e);
+        if (typeof Module !== 'undefined' && Module.switchPreset) {
+            Module.switchPreset();
+        }
     }
 });
 

--- a/projectM_emscripten.cpp
+++ b/projectM_emscripten.cpp
@@ -684,10 +684,10 @@ console.log('Got /presets/preset_'+(startIdx+i)+'.milk from '+milkSrc+'.');
 
 downloadFromArray($milk,total,idx);
 
-Module.addPath();
 setTimeout(function(){
+Module.addPath();
 Module.startRender(window.innerHeight, window.innerHeight);
-},1000);
+},2500);
 }
 var pth=document.querySelector('#milkPath').innerHTML;
 scanTextures();


### PR DESCRIPTION
## Summary
Fixed critical timing issue preventing the random preset button from working properly.

## Changes
- **Fix timing issue**: Moved `Module.addPath()` call inside setTimeout to ensure preset files are written to VFS before the playlist is populated
- **Increase reliability**: Extended timeout from 1000ms to 2500ms to allow all async XMLHttpRequest downloads to complete
- **Add API validation**: Added checks for required response fields (url, filename, dir) with clear error messages
- **Add fallback behavior**: Random Preset (API) button now falls back to local preset switching if API is unavailable
- **Improve error handling**: Better error logging showing when fallback is being used

## Why it was broken
The previous implementation called `Module.addPath()` immediately after starting async XMLHttpRequest downloads. Since the downloads were still in flight, no preset files existed in the VFS yet, resulting in an empty playlist. This made the "Random Preset" button have nothing to play.

---
_Generated by [Claude Code](https://claude.ai/code/session_014LujHe9ESz36DfUMaNVRwe)_