### PR TITLE
Fix canvas centering in bezel mode

### DIFF
--- a/html/projectm-core.html
+++ b/html/projectm-core.html
@@ -101,6 +101,7 @@ function updateLayout() {
             contain1.style.width = sz + 'px';
             contain1.style.height = sz + 'px';
             contain1.style.left = 'calc(50vw - ' + (sz / 2) + 'px)';
+            contain1.style.top = 'calc(50vh - ' + (sz / 2) + 'px)';
             contain1.style.position = 'absolute';
         }
 


### PR DESCRIPTION
## Problem
When toggling the fullscreen button, the canvas was appearing off-center in bezel mode. The canvas container was missing vertical centering.

## Solution
Added the missing `top` style calculation in bezel mode to center the canvas vertically, matching the existing horizontal centering. Now the canvas stays properly centered when switching between fullscreen and bezel modes.

## Changes
- Added `top: calc(50vh - sz/2px)` to the canvas container in bezel mode layout

This fixes the centering issue while maintaining all existing functionality.

---
_Generated by [Claude Code](https://claude.ai/code/session_0131nokcRHeMm899kqWJ1W5b)_