### PR TITLE
Fix Emscripten initialization in HTML files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ if(ENABLE_EMSCRIPTEN)
             "SHELL:-s MIN_WEBGL_VERSION=2 "
             "SHELL:-s MAX_WEBGL_VERSION=2 "
             "SHELL:-s USE_WEBGL2=1 -s FULL_ES2=0 -s FULL_ES3=1 -s GL_POOL_TEMP_BUFFERS=0 -s GL_MAX_TEMP_BUFFER_SIZE=33177600 -s GL_TRACK_ERRORS=0 "
-            "SHELL:-s NO_DISABLE_EXCEPTION_CATCHING -s ALLOW_MEMORY_GROWTH=1 -sMALLOC='mimalloc' -sMAXIMUM_MEMORY=4gb -sINITIAL_HEAP=1024mb "
+            "SHELL:-s NO_DISABLE_EXCEPTION_CATCHING -s ALLOW_MEMORY_GROWTH=1 -sMALLOC='mimalloc' -sMAXIMUM_MEMORY=4gb -sINITIAL_MEMORY=1024mb "
             "SHELL:-msimd128 -mrelaxed-simd -fopenmp -lomp -mmutable-globals -mbulk-memory -matomics -mnontrapping-fptoint -msign-ext -fno-strict-aliasing "
             "SHELL:--typed-function-references --enable-reference-types -fno-math-errno "
             "SHELL:-s TRUSTED_TYPES=1 -s WASM_BIGINT=1 -sAUDIO_WORKLET=1 "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ if(ENABLE_EMSCRIPTEN)
             "SHELL:-msimd128 -mrelaxed-simd -fopenmp -lomp -mmutable-globals -mbulk-memory -matomics -mnontrapping-fptoint -msign-ext -fno-strict-aliasing "
             "SHELL:--typed-function-references --enable-reference-types -fno-math-errno "
             "SHELL:-s TRUSTED_TYPES=1 -s WASM_BIGINT=1 -sAUDIO_WORKLET=1 "
-            "SHELL:-s FORCE_FILESYSTEM=1 -s ASYNCIFY=1 -s EXPORTED_RUNTIME_METHODS=['cwrap', 'ccall'] -s EXPORTED_FUNCTIONS=['_main', '_projectm_touch']"
+            "SHELL:-s FORCE_FILESYSTEM=1 -s ASYNCIFY=1 -s EXPORTED_RUNTIME_METHODS='ccall,cwrap' -s EXPORTED_FUNCTIONS='_main,_projectm_touch'"
             )
 
     # if(USE_PTHREADS)

--- a/html/projectm-core.html
+++ b/html/projectm-core.html
@@ -270,8 +270,9 @@ setTimeout(function(){
     document.body.appendChild(scr);
 
     setTimeout(function(){
-        Module = createModule();
-        Module.onRuntimeInitialized = async function(){
+        createModule().then(async function(instance) {
+            Module = instance;
+
             Module.init();
             updateLayout();
             const mcanvas = document.querySelector('#mcanvas');
@@ -288,7 +289,7 @@ setTimeout(function(){
             }
 
             Module.startRender(mcanvas.width, mcanvas.height);
-        };
+        });
     }, 1000);
 }, 750);
 

--- a/html/projectm.1ink
+++ b/html/projectm.1ink
@@ -432,7 +432,7 @@ antialias:true,
 willReadFrequently:false,
 majorVersion:2,
 minorVersion:0
-};
+});
 
 bctx=ccs.getContext('2d',params);
 ttx=tc.getContext('2d',params);
@@ -564,7 +564,7 @@ setTimeout(function(){
 document.body.appendChild(scr);
 },200);
 }
-};
+});
 xhr.send();
 
 var imgChan=new BroadcastChannel('imageURL');
@@ -658,7 +658,7 @@ document.querySelector('#tvi').style.position='absolute';
 document.querySelector('#tvi').style.zIndex=3300;
 document.querySelector('#tvi').style.pointerEvents='auto';
 },6500);
-};
+});
 
 pyChannel.addEventListener('message', (event) => {
 const message = event.data;
@@ -700,7 +700,7 @@ const reader = new FileReader();
 reader.onload = (e) => {
 const imageDataURL = e.target.result;
 processImage(imageDataURL);
-};
+});
 reader.readAsDataURL(file);
 }
 });
@@ -1082,7 +1082,7 @@ console.log('got py image');
 xhr.onload = function() {
 const imageData = xhr.response;
 processImage(imageData); // Reuse the processImage function
-};
+});
 xhr.send();
 }
 
@@ -1158,10 +1158,10 @@ var Module = libapng();
 Module.onRuntimeInitialized = function(){
 Module.callMain();
 console.log('call main');
-};
+});
 },2500);
 }
-};
+});
 xhr.send();
 });
 
@@ -1177,8 +1177,9 @@ scr.defer=true;
 scr.src="./pm/projectm-v.024-thread.1ijs";
 document.body.appendChild(scr);
 setTimeout(function(){
-Module=createModule();
-Module.onRuntimeInitialized=async function(){
+createModule().then(async function(instance) {
+Module=instance;
+
 Module.init();
 updateLayout();
 const mcanvas = document.querySelector('#mcanvas');
@@ -1193,7 +1194,7 @@ if (startupPaths.length > 0) {
     Module.switchPreset();
 }
 Module.startRender(mcanvas.width, mcanvas.height);
-};
+});
 },1000);
 });
 


### PR DESCRIPTION
This fixes the issue where `Module` was a Promise instead of the module instance, causing `Module.loadPresetFile` and `Module.switchPreset` to be undefined in button click handlers.

---
*PR created automatically by Jules for task [486983948415070559](https://jules.google.com/task/486983948415070559) started by @ford442*