### PR TITLE
Expose panel button handlers on window for inline onclick

### DIFF
--- a/html/projectm_panel.1ink
+++ b/html/projectm_panel.1ink
@@ -490,6 +490,18 @@ function toggleFullscreen() {
     }
 }
 
+// Expose handlers globally so inline onclick attributes can find them
+// (module scripts don't expose top-level declarations to window).
+window.lockPreset = lockPreset;
+window.hidePanel = hidePanel;
+window.showPanel = showPanel;
+window.flacPlayer = flacPlayer;
+window.startChangeSong = startChangeSong;
+window.randomPreset = randomPreset;
+window.fullWindow = fullWindow;
+window.randomCustom = randomCustom;
+window.toggleFullscreen = toggleFullscreen;
+
 // ====== CANVAS MANAGEMENT ======
 function updateLayout() {
     const mcanvas = document.querySelector('#mcanvas');


### PR DESCRIPTION
The handlers are defined inside <script type="module">, whose top-level declarations don't reach the global scope, so inline onclick attributes threw ReferenceError. Attach them to window explicitly.