### PR TITLE
Update deploy targets and asset URLs to projectm.1ink.us

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -14,7 +14,7 @@ files = [
 ]
 
 local_dir = "/root/Project-M"
-remote_bases = ["wasm.noahcohn.com/pm/", "noahcohn.com/pm/"]
+remote_bases = ["projectm.1ink.us/"]
 
 for filename in files:
     local_path = os.path.join(local_dir, filename)

--- a/html/projectm_panel.1ink
+++ b/html/projectm_panel.1ink
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel='preconnect' href='https://wasm.noahcohn.com'>
+<link rel='preconnect' href='https://projectm.1ink.us'>
 <link rel='preconnect' href='https://js.1ink.us'>
 <link rel='preconnect' href='https://glsl.1ink.us'>
 <title>ProjectM with Control Panel</title>
@@ -433,7 +433,7 @@ async function fetchApiPreset(apiBase) {
 }
 
 async function loadStartupApiPresets(count) {
-    const apiBase = localStorage.getItem('apiBase') || 'https://storage.noahcohn.com';
+    const apiBase = localStorage.getItem('apiBase') || 'https://projectm.1ink.us';
     const results = [];
     for (let i = 0; i < count; i++) {
         try {
@@ -452,7 +452,7 @@ async function loadRandomApiPreset() {
         console.error('Module not ready');
         return;
     }
-    const apiBase = localStorage.getItem('apiBase') || 'https://storage.noahcohn.com';
+    const apiBase = localStorage.getItem('apiBase') || 'https://projectm.1ink.us';
     try {
         const result = await fetchApiPreset(apiBase);
         Module.ccall('load_preset_file', null, ['string'], [result.vfsPath]);

--- a/scripts/colab_deploy.sh
+++ b/scripts/colab_deploy.sh
@@ -16,7 +16,7 @@ USERNAME="${USERNAME:-ford442}"
 PASSWORD="${PASSWORD:-${SFTP_PASS:-GoogleBez12!}}"
 PORT="${PORT:-22}"
 
-REMOTE_BASES=("wasm.noahcohn.com/pm/" "noahcohn.com/pm/")
+REMOTE_BASES=("projectm.1ink.us/")
 UPLOAD_FILES=(
     "projectm-v.024-thread.1ijs"
     "projectm-v.024-thread.wasm"

--- a/scripts/upload_project.sh
+++ b/scripts/upload_project.sh
@@ -24,8 +24,7 @@ FILES=(
 
 # Both destinations (matches your original script)
 REMOTE_BASES=(
-    "wasm.noahcohn.com/pm/"
-    "noahcohn.com/pm/"
+    "projectm.1ink.us/"
 )
 # =====================================
 

--- a/upload_module.py
+++ b/upload_module.py
@@ -13,23 +13,19 @@ port = 22
 file_name=loc_file1
 local_path="/root/projectm/"+file_name
 transport = paramiko.Transport((host, port))
-destination_path="wasm.noahcohn.com/pm/"+file_name
-destination_path2="noahcohn.com/pm/"+file_name
+destination_path="projectm.1ink.us/"+file_name
 transport.connect(username = username, password = password)
 sftp = paramiko.SFTPClient.from_transport(transport)
 sftp.put(local_path, destination_path)
-sftp.put(local_path, destination_path2)
 sftp.close()
 transport.close()
 file_name2=loc_file2
 local_path="/root/projectm/"+file_name2
 transport = paramiko.Transport((host, port))
-destination_path="wasm.noahcohn.com/pm/"+file_name2
-destination_path2="noahcohn.com/pm/"+file_name2
+destination_path="projectm.1ink.us/"+file_name2
 transport.connect(username = username, password = password)
 sftp = paramiko.SFTPClient.from_transport(transport)
 sftp.put(local_path, destination_path)
-sftp.put(local_path, destination_path2)
 sftp.close()
 transport.close()
 loc_file3 = "projectm-v.024-thread.3ijs" #@param ["sh4.1ijs", "sh5.1ijs", "g3007.wasm", "g3008.wasm", "g3009.wasm", "sh6.1ijs", "g3010.wasm"] {allow-input: true}
@@ -45,7 +41,7 @@ port = 22
 file_name=loc_file3
 local_path="/root/projectm/"+file_name
 transport = paramiko.Transport((host, port))
-destination_path="wasm.noahcohn.com/pm/"+file_name
+destination_path="projectm.1ink.us/"+file_name
 transport.connect(username = username, password = password)
 sftp = paramiko.SFTPClient.from_transport(transport)
 sftp.put(local_path, destination_path)


### PR DESCRIPTION
Replace wasm.noahcohn.com/pm/ and noahcohn.com/pm/ remote paths with projectm.1ink.us/ across all deploy scripts and HTML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated deployment infrastructure and API endpoints to use a single unified domain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Project-M/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->