### PR TITLE
Fix init cascade, bezel loading, domain migration, resource hints

### DIFF
--- a/html/projectm_panel2.1ink
+++ b/html/projectm_panel2.1ink
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel='preconnect' href='https://wasm.noahcohn.com'>
 <link rel='preconnect' href='https://js.1ink.us'>
 <link rel='preconnect' href='https://glsl.1ink.us'>
+<link rel='preconnect' href='https://storage.1ink.us'>
+<link rel="preload" as="image" href="./image/panel-bg.jpg" fetchpriority="high">
+<link rel="preload" as="image" href="./image/shroud.jpg">
+<link rel="preload" as="script" href="./pm/projectm-v.030-thread.1ijs">
 <title>B3HD • ProjectM</title>
 
 <style>
@@ -174,7 +178,7 @@ body.has-lock .led--lock { background: #f59e0b; box-shadow: 0 0 7px 2px rgba(245
 <div hidden id="lns">1</div>
 <div hidden id="presetDir">default</div>
 <div hidden id="milkPath">https://glsl.1ink.us/milk/flexi.milk</div>
-<div hidden id="birdsongPath">https://www.noahcohn.com/birdsongs/26HouseFinchSong.mp3</div>
+<div hidden id="birdsongPath">https://projectm.1ink.us/birdsongs/26HouseFinchSong.mp3</div>
 
 <audio crossorigin id="track" preload="none" style="pointer-events:none;"></audio>
 
@@ -185,8 +189,8 @@ body.has-lock .led--lock { background: #f59e0b; box-shadow: 0 0 7px 2px rgba(245
 </section>
 
 <!-- Bezel assets -->
-<img src='./unglass.png' id="gl" alt="Glass" style="display:none;">
-<img src='./bezel.jpg' id="frm" hidden alt="Frame"/>
+<img src='https://projectm.1ink.us/unglass.png' id="gl" alt="Glass" style="display:none;" crossorigin="anonymous">
+<img src='https://projectm.1ink.us/bezel.jpg' id="frm" hidden alt="Frame" crossorigin="anonymous"/>
 <canvas id="tcan" hidden></canvas>
 
 <script>
@@ -211,12 +215,26 @@ function op(sz){
 }
 
 function drawBezel(){
+  img = document.querySelector('#frm');
+  imgb = document.querySelector('#gl');
+
+  // Defer until both bezel images are loaded
+  if (!img.complete || !img.naturalWidth || !imgb.complete || !imgb.naturalWidth) {
+    const onLoad = () => {
+      img.removeEventListener('load', onLoad);
+      imgb.removeEventListener('load', onLoad);
+      drawBezel();
+    };
+    img.addEventListener('load', onLoad);
+    imgb.addEventListener('load', onLoad);
+    return;
+  }
+
   hi = window.innerHeight;
   rec = Math.round(window.innerWidth);
   document.querySelector('#circle').width = rec;
   document.querySelector('#circle').height = hi;
 
-  imgb = document.querySelector('#gl');
   glas = Math.round(hi * 1.133);
   imgb.height = glas; imgb.width = glas;
 
@@ -226,7 +244,6 @@ function drawBezel(){
   tc = document.querySelector('#tcan');
   tc.height = hi;
 
-  img = document.querySelector('#frm');
   mdd = Math.round((rec - glas) / 2);
   gtop = Math.round((imgb.height - hi) / 2);
   imgb.style.cssText = `position:absolute;left:${mdd}px;right:${mdd}px;z-index:555;top:-${gtop}px;`;
@@ -351,7 +368,7 @@ function getPresetDir() {
   return (el && el.innerHTML.trim() !== 'default') ? el.innerHTML.trim() : 'any';
 }
 
-async function fetchApiPreset(apiBase = 'https://storage.noahcohn.com') {
+async function fetchApiPreset(apiBase = 'https://storage.1ink.us') {
   const dir = getPresetDir();
   const res = await fetch(`${apiBase}/api/presets/random?dir=${encodeURIComponent(dir)}`);
   if (!res.ok) throw new Error('API error');
@@ -366,7 +383,7 @@ async function fetchApiPreset(apiBase = 'https://storage.noahcohn.com') {
 }
 
 async function loadStartupApiPresets(count = 5) {
-  const apiBase = localStorage.getItem('apiBase') || 'https://storage.noahcohn.com';
+  const apiBase = localStorage.getItem('apiBase') || 'https://storage.1ink.us';
   const results = [];
   for (let i = 0; i < count; i++) {
     try {
@@ -498,44 +515,50 @@ document.addEventListener('keydown', e => {
 // ===== INITIALIZATION =====
 updateLayout();
 
-setTimeout(() => { document.getElementById('splash2').style.display = 'none'; }, 5200);
-setTimeout(() => { document.getElementById('splash1').style.display = 'none'; }, 5500);
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const scr = document.createElement('script');
+    scr.src = src;
+    scr.async = true;
+    scr.charset = 'utf-8';
+    scr.onload = () => resolve();
+    scr.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.body.appendChild(scr);
+  });
+}
 
-setTimeout(() => {
-  const scr = document.createElement("script");
-  scr.async = true; scr.charset = 'utf-8'; scr.type = 'text/javascript'; scr.defer = true;
-  scr.src = "./pm/projectm-v.030-thread.1ijs";
-  document.body.appendChild(scr);
+async function initProjectM() {
+  try {
+    await loadScript('./pm/projectm-v.030-thread.1ijs');
+    Module = await createModule();
+    Module._init();
+    updateLayout();
+    syncModuleSize();
 
-  setTimeout(async () => {
-    try {
-      Module = await createModule();
-      Module._init();
-      updateLayout();
-      syncModuleSize();
+    document.getElementById('splash2').style.display = 'none';
+    requestAnimationFrame(() => {
+      document.getElementById('splash1').style.display = 'none';
+    });
 
-      const mcanvas = document.querySelector('#mcanvas');
-      Module._start_render(mcanvas.width, mcanvas.height);
+    const mcanvas = document.querySelector('#mcanvas');
+    Module._start_render(mcanvas.width, mcanvas.height);
 
-      const startup = await loadStartupApiPresets(5);
-      if (startup.length > 0) {
-        Module.ccall('load_preset_file', null, ['string'], [startup[0].vfsPath]);
-        window.updatePresetDisplay(startup[0].filename);
-        for (let i = 1; i < startup.length; i++) {
-          Module.ccall('add_preset_file', null, ['string'], [startup[i].vfsPath]);
-        }
+    document.getElementById('musicBtn').click();
+
+    const startup = await loadStartupApiPresets(5);
+    if (startup.length > 0) {
+      Module.ccall('load_preset_file', null, ['string'], [startup[0].vfsPath]);
+      window.updatePresetDisplay(startup[0].filename);
+      for (let i = 1; i < startup.length; i++) {
+        Module.ccall('add_preset_file', null, ['string'], [startup[i].vfsPath]);
       }
-    } catch (err) {
-      console.error('projectM init failed:', err);
     }
-  }, 900);
-}, 750);
+  } catch (err) {
+    console.error('projectM init failed:', err);
+  }
+}
 
-// Auto click music button after load
-setTimeout(() => {
-  const mb = document.getElementById('musicBtn');
-  if (mb) mb.click();
-}, 3200);
+initProjectM();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace blind setTimeout cascade with event-driven `loadScript()` + `initProjectM()` — splash hides only after WASM is ready, no more `createModule is not defined` on slow connections
- Fix `drawBezel()` silently no-oping: it was reading `naturalWidth=0` before bezel images loaded; now defers via load event listener
- Use absolute URLs for `unglass.png` / `bezel.jpg` at `projectm.1ink.us`
- Migrate all `noahcohn.com` references (storage API, birdsong path, preconnect) to `1ink.us`
- Add `meta charset=utf-8`, preload hints for panel image + splash + WASM script
- Move `musicBtn.click()` inside `initProjectM()` after successful startup

## Test plan
- [ ] Page loads — visualization appears, no grey canvas
- [ ] Splash hides only after WASM is ready (not on a fixed 5s timer)
- [ ] Bezel ring draws correctly around the visualization
- [ ] No 404s for `noahcohn.com` resources in Network panel
- [ ] Slow 3G sim: no `createModule is not defined` console errors
- [ ] All 8 panel buttons respond to clicks

https://claude.ai/code/session_01KrcdShHy2C4kMUqjapx4sR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrcdShHy2C4kMUqjapx4sR)_