### PR TITLE
Calibrate panel button hotspots to align with panel-bg.jpg

### DIFF
--- a/html/projectm_panel2.1ink
+++ b/html/projectm_panel2.1ink
@@ -153,14 +153,15 @@ body.has-lock .led--lock { background: #f59e0b; box-shadow: 0 0 7px 2px rgba(245
   </div>
 
   <!-- Clickable areas -->
-  <button id="lockPresetBtn" onclick="lockPreset()" class="clickable-button" style="top:9%;left:34%;width:32%;height:12%;"></button>
-  <button onclick="hidePanel()" class="clickable-button" style="top:16%;left:10%;width:22%;height:16%;"></button>
-  <button onclick="flacPlayer()" class="clickable-button" style="top:16%;right:10%;width:22%;height:16%;"></button>
-  <button id="musicBtn" onclick="startChangeSong()" class="clickable-button" style="top:34%;left:2%;width:22%;height:18%;"></button>
-  <button id="randomPresetBtn" onclick="randomPreset()" class="clickable-button" style="top:34%;right:2%;width:22%;height:18%;"></button>
-  <button id="toggleBezelBtn" onclick="fullWindow()" class="clickable-button" style="top:52%;left:10%;width:22%;height:16%;"></button>
-  <button id="customMilkBtn" onclick="randomCustom()" class="clickable-button" style="top:52%;right:10%;width:22%;height:16%;"></button>
-  <button onclick="toggleFullscreen()" class="clickable-button" style="top:67%;left:34%;width:32%;height:13%;"></button>
+  <!-- Calibrated against panel-bg.jpg (circular ring of 8 buttons around centered knob) -->
+  <button id="lockPresetBtn" onclick="lockPreset()" class="clickable-button" style="top:14%;left:34%;width:32%;height:12%;"></button>
+  <button onclick="hidePanel()" class="clickable-button" style="top:22%;left:14%;width:22%;height:16%;"></button>
+  <button onclick="flacPlayer()" class="clickable-button" style="top:22%;right:14%;width:22%;height:16%;"></button>
+  <button id="musicBtn" onclick="startChangeSong()" class="clickable-button" style="top:38%;left:6%;width:22%;height:18%;"></button>
+  <button id="randomPresetBtn" onclick="randomPreset()" class="clickable-button" style="top:38%;right:6%;width:22%;height:18%;"></button>
+  <button id="toggleBezelBtn" onclick="fullWindow()" class="clickable-button" style="top:56%;left:14%;width:22%;height:16%;"></button>
+  <button id="customMilkBtn" onclick="randomCustom()" class="clickable-button" style="top:56%;right:14%;width:22%;height:16%;"></button>
+  <button onclick="toggleFullscreen()" class="clickable-button" style="top:64%;left:34%;width:32%;height:13%;"></button>
 
   <div id="knob" class="knob"></div>
 </div>


### PR DESCRIPTION
The clickable button overlays in `html/projectm_panel2.1ink` were spread outward relative to where the buttons actually appear on `panel-bg.jpg`. Debug outlines showed each hotspot sitting on the wrong side of its button (top button too high, bottom button too low, side buttons too far out).

Compressed all hotspots toward the centered knob:

| Button | top | inner edge |
|---|---|---|
| Lock Preset | 9% → 14% | — |
| Hide / Flac Player | 16% → 22% | 10% → 14% |
| Music / Random Preset | 34% → 38% | 2% → 6% |
| Full Window / Random Custom | 52% → 56% | 10% → 14% |
| Fullscreen | 67% → 64% | — |

Widths/heights unchanged. Likely needs another visual pass against debug outlines to refine — leaving as draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJQxwvkVvjEUCCCpK7SFfG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button positioning on the circular control panel with improved layout coordinates for better alignment and spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Project-M/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->