### PR TITLE
Calibrate control button positions to panel artwork

### DIFF
--- a/html/projectm-core.css
+++ b/html/projectm-core.css
@@ -138,8 +138,8 @@ img[id^="logo"] {
 /* Control Buttons - positioned around the circular panel */
 .control-btn {
   position: absolute;
-  width: 60px;
-  height: 50px;
+  width: 75px;
+  height: 55px;
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -177,50 +177,50 @@ img[id^="logo"] {
 /* Calibrated to overlay button artwork in panel-bg.jpg (768px source -> 409px container) */
 /* Hide Controls (top-left) */
 .hide-controls-btn {
-  left: 87px;
-  top: 90px;
+  left: 80px;
+  top: 88px;
 }
 
 /* Lock Preset (top-center) */
 .lock-preset-btn {
-  left: 175px;
-  top: 63px;
+  left: 167px;
+  top: 60px;
 }
 
 /* Flac Player (top-right) */
 .flac-player-btn {
-  left: 266px;
-  top: 90px;
+  left: 258px;
+  top: 88px;
 }
 
 /* Start / Change Song (left) */
 .music-btn {
-  left: 58px;
-  top: 178px;
+  left: 50px;
+  top: 176px;
 }
 
 /* Random Preset (right) */
 .random-preset-btn {
-  left: 295px;
-  top: 178px;
+  left: 287px;
+  top: 176px;
 }
 
 /* Full Window (bottom-left) */
 .full-window-btn {
-  left: 85px;
-  bottom: 96px;
+  left: 78px;
+  bottom: 93px;
 }
 
 /* Fullscreen (bottom-center) */
 .fullscreen-btn {
-  left: 175px;
-  bottom: 70px;
+  left: 167px;
+  bottom: 67px;
 }
 
 /* Random Custom (bottom-right) */
 .custom-milk-btn {
-  left: 266px;
-  bottom: 96px;
+  left: 258px;
+  bottom: 93px;
 }
 
 /* API Preset Button - hidden but functional */

--- a/html/projectm-core.css
+++ b/html/projectm-core.css
@@ -174,52 +174,53 @@ img[id^="logo"] {
 }
 
 /* Button Positioning around the circular panel */
+/* Calibrated to overlay button artwork in panel-bg.jpg (768px source -> 409px container) */
 /* Hide Controls (top-left) */
 .hide-controls-btn {
-  left: 60px;
-  top: 50px;
+  left: 87px;
+  top: 90px;
 }
 
 /* Lock Preset (top-center) */
 .lock-preset-btn {
   left: 175px;
-  top: 20px;
+  top: 63px;
 }
 
 /* Flac Player (top-right) */
 .flac-player-btn {
-  left: 290px;
-  top: 50px;
+  left: 266px;
+  top: 90px;
 }
 
 /* Start / Change Song (left) */
 .music-btn {
-  left: 15px;
-  top: 180px;
+  left: 58px;
+  top: 178px;
 }
 
 /* Random Preset (right) */
 .random-preset-btn {
-  right: 15px;
-  top: 180px;
+  left: 295px;
+  top: 178px;
 }
 
 /* Full Window (bottom-left) */
 .full-window-btn {
-  left: 60px;
-  bottom: 50px;
+  left: 85px;
+  bottom: 96px;
 }
 
 /* Fullscreen (bottom-center) */
 .fullscreen-btn {
   left: 175px;
-  bottom: 20px;
+  bottom: 70px;
 }
 
 /* Random Custom (bottom-right) */
 .custom-milk-btn {
-  left: 290px;
-  bottom: 50px;
+  left: 266px;
+  bottom: 96px;
 }
 
 /* API Preset Button - hidden but functional */


### PR DESCRIPTION
## Summary
- Repositioned all 8 control buttons so the clickable overlays align with the button artwork drawn on `panel-bg.jpg` (positions were derived from the 768→409 px scale factor).
- Bumped button hit area from 60x50 to 75x55 and recentered each button so the larger box stays centered on the artwork.

## Test plan
- [ ] Reload the panel with debug outlines enabled and confirm each red box sits over its corresponding button artwork.
- [ ] Click each button (Hide Controls, Lock Preset, Flac Player, Start/Change Song, Random Preset, Full Window, Fullscreen, Random Custom Preset) and verify the action fires.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDY91LDjQGsL68x769hfZN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined control button dimensions and repositioned overlay controls in the circular control panel for improved layout and visual consistency. Updated placement rules for preset management, music playback controls, fullscreen mode, random preset selection, and other interface elements to enhance spacing and alignment across all interactive controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Project-M/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->