### PR TITLE
Fix Full Window button in projectm_panel2: toggle bezel mode

### DIFF
--- a/html/projectm_panel2.1ink
+++ b/html/projectm_panel2.1ink
@@ -405,10 +405,13 @@ function flacPlayer() {
   section.style.display = visible ? 'none' : 'block';
 }
 function fullWindow() {
-  isBezelMode = true;
+  isBezelMode = !isBezelMode;
+  if (!isBezelMode && document.fullscreenElement) {
+    document.exitFullscreen().catch(()=>{});
+  }
   updateLayout();
   syncModuleSize();
-  drawBezel();
+  if (isBezelMode) drawBezel();
 }
 function lockPreset() {
   isPresetLocked = !isPresetLocked;


### PR DESCRIPTION
fullWindow() unconditionally set isBezelMode=true, but the default is already true, so the button had no visible effect. Mirror the original projectm.1ink behavior by toggling between bezel and full-window layouts, and exit fullscreen if leaving bezel mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed bezel mode toggle functionality to properly handle fullscreen state. Bezel mode can now be enabled and disabled correctly, with fullscreen mode properly exiting when bezel mode is turned off.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ford442/Project-M/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->