### PR TITLE
Fix 033-thread deploy: mirror WASM under pm/ and ship HTML host modules

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -31,9 +31,24 @@ import requests
 PROJECT_NAME: str = "project-m"
 CONTABO_BASE_URL: str = "https://storage.noahcohn.com"
 
-# Files to deploy — globs matched against the project root.
-# These are the compiled WASM + JS output artifacts.
-DEPLOY_FILE_PATTERNS: list = ["*.wasm", "*.1ijs", "*.3ijs"]
+# WASM artifacts at the repo root (built + iconv'd before deploy).
+DEPLOY_FILE_PATTERNS: list = [
+    "projectm-v.*-thread.wasm",
+    "projectm-v.*-thread.1ijs",
+    "projectm-v.*-thread.3ijs",
+    "projectm-v.*-thread.worker.js",
+]
+
+# Host pages load the module from ./pm/…; mirror every WASM artifact there too.
+DEPLOY_MIRROR_SUBDIRS: list = ["pm"]
+
+# Shared browser modules and demo hosts (flattened to the deploy root).
+DEPLOY_HTML_GLOBS: list = [
+    "html/projectm-*.js",
+    "html/projectm-*.1ink",
+    "html/projectm-core.html",
+    "html/projectm-core.css",
+]
 
 # Deploy under this remote folder (empty = use PROJECT_NAME).
 # Matches the original SFTP remote target: projectm.1ink.us/
@@ -46,23 +61,71 @@ DEPLOY_TOKEN: str = os.environ.get("DEPLOY_TOKEN", "")
 HERE = Path(__file__).parent
 
 
-def build_zip() -> bytes:
-    """Zip only the WASM/JS output files from the project root."""
-    buf = io.BytesIO()
+def _unique_paths(paths: list[Path]) -> list[Path]:
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for path in paths:
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        ordered.append(path)
+    return ordered
+
+
+def collect_deploy_files() -> list[Path]:
     matched: list[Path] = []
     for pattern in DEPLOY_FILE_PATTERNS:
-        matched.extend(sorted(HERE.glob(pattern)))
+        matched.extend(HERE.glob(pattern))
+
+    for pattern in DEPLOY_HTML_GLOBS:
+        matched.extend(HERE.glob(pattern))
+
+    return _unique_paths(matched)
+
+
+def zip_entry_name(file: Path) -> str:
+    """Place html/ sources at the deploy root (hosts import ./projectm-*.js)."""
+    try:
+        relative = file.relative_to(HERE)
+    except ValueError:
+        return file.name
+
+    if relative.parts and relative.parts[0] == "html":
+        return str(Path(*relative.parts[1:]))
+    return file.name
+
+
+def build_zip() -> bytes:
+    """Zip WASM artifacts (plus pm/ mirrors) and shared html host files."""
+    matched = collect_deploy_files()
 
     if not matched:
         print("ERROR: No files matched deploy patterns:")
-        for p in DEPLOY_FILE_PATTERNS:
-            print(f"  {p}")
+        for pattern in DEPLOY_FILE_PATTERNS + DEPLOY_HTML_GLOBS:
+            print(f"  {pattern}")
         sys.exit(1)
 
+    wasm_files = [
+        path for path in matched if path.suffix in {".wasm", ".1ijs", ".3ijs", ".js"}
+        and path.name.startswith("projectm-v.")
+        and "-thread." in path.name
+        and path.parent == HERE
+    ]
+
+    buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for file in matched:
-            zf.write(file, file.name)
-            print(f"  + {file.name}")
+            archive_name = zip_entry_name(file)
+            zf.write(file, archive_name)
+            print(f"  + {archive_name}")
+
+            if file in wasm_files:
+                for subdir in DEPLOY_MIRROR_SUBDIRS:
+                    mirrored = f"{subdir}/{file.name}"
+                    zf.write(file, mirrored)
+                    print(f"  + {mirrored} (mirror)")
+
     return buf.getvalue()
 
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,15 +1,49 @@
 # Deployment
 
-`deploy.py` uploads the compiled WASM/JS bundle (`*.wasm`, `*.1ijs`, `*.3ijs` in the
-repo root) to `storage.noahcohn.com`, which pushes it to `projectm.1ink.us/` via a
-persistent SFTP connection on the VPS side. No SFTP credentials are stored in this repo
+`deploy.py` uploads the compiled WASM/JS bundle and shared HTML host modules to
+`storage.noahcohn.com`, which pushes them to `projectm.1ink.us/` via a persistent
+SFTP connection on the VPS side. No SFTP credentials are stored in this repo
 for this path.
+
+## What gets deployed
+
+WASM artifacts at the **repo root** (after `scripts/prepare_deploy_bundle.sh`):
+
+- `projectm-v.<ver>-thread.wasm`
+- `projectm-v.<ver>-thread.1ijs` (UTF-16 wrapper around the `.js` glue)
+- `projectm-v.<ver>-thread.3ijs`
+- `projectm-v.<ver>-thread.worker.js` (when Emscripten emits a separate worker)
+
+Each WASM artifact is uploaded **twice**: once at the site root and again under
+`pm/`. Host pages load the module from `./pm/projectm-v.<ver>-thread.1ijs`; the
+`.wasm` sibling is resolved relative to that script URL. Deploying only to the
+site root (without the `pm/` mirror) produces HTTP 404 HTML responses and the
+browser error **Unexpected token '<'** when parsing the missing script.
+
+Shared browser modules and demo hosts from `html/` (flattened to the deploy
+root, because hosts `import './projectm-*.js'`):
+
+- `projectm-*.js`, `projectm-*.1ink`, `projectm-core.html`, `projectm-core.css`
+
+The active bundle version is defined once in `html/projectm-init.js`
+(`PROJECTM_WASM_BUNDLE`, currently `projectm-v.033-thread`). Bump it when you
+publish a new smoke build.
 
 ## Usage
 
 ```bash
+# 1. Build + stage artifacts at repo root and pm/
+PROJECTM_WASM_VERSION=033 \
+  INSTALL_DIR=install OUT_DIR=cmake-build/wasm-smoke \
+  scripts/prepare_deploy_bundle.sh
+
+# 2. Upload
 export DEPLOY_TOKEN="your_long_token_from_vps_env"
 python deploy.py
+
+# 3. Verify (no HTML 404s under pm/)
+scripts/verify_deploy_urls.sh https://projectm.1ink.us/ projectm-v.033-thread
+scripts/check_coop_coep.sh https://projectm.1ink.us/
 ```
 
 `deploy.py` **requires** `DEPLOY_TOKEN` to be set in the environment and exits with an
@@ -138,6 +172,19 @@ Run this after deploying (e.g. as a follow-up step to `python deploy.py`, or in 
 against a staging URL) to catch a server config regression before it breaks
 threaded/audio features in production. You can also verify manually in the browser
 console on the deployed page: `crossOriginIsolated` should be `true`.
+
+## Troubleshooting: `Unexpected token '<'` / panel 404s
+
+| Symptom | Typical cause | Fix |
+|---------|---------------|-----|
+| `Unexpected token '<'` loading `projectm-v.*.1ijs` | `./pm/…` path 404 (Apache returns HTML) | Re-run `python deploy.py` after `prepare_deploy_bundle.sh` so `pm/` mirrors exist; or copy all four artifacts into your site's `pm/` folder |
+| Module loads but WASM fails | `.wasm` missing next to the `.1ijs` under the same directory | Deploy/copy `pm/projectm-v.<ver>-thread.wasm` alongside the `.1ijs` |
+| `projectm_panel2.1ink` 404 on `projectm-*.js` | Only WASM was deployed; HTML modules were not | Include `html/projectm-*.js` in the bundle (`deploy.py` does this automatically) |
+| Duplicate script tags (root + `pm/`) | Custom host loads `./projectm-v.*.1ijs` and `./pm/…` | Load **only** from `./pm/` via `PROJECTM_WASM_SCRIPT` in `projectm-init.js` |
+
+Custom hosts on other domains must mirror the full `pm/` directory locally (or
+symlink to `https://projectm.1ink.us/pm/…` with CORP headers). Loading from
+`js.1ink.us` only works if that host also carries the complete `pm/` tree.
 
 ## Other deploy-related scripts (legacy / audit)
 

--- a/html/projectm-core.html
+++ b/html/projectm-core.html
@@ -522,7 +522,7 @@ import { setupContextLossRecovery } from './projectm-context-loss.js';
 import { defaultFeedPCMToModule, feedPCMToModule, flushQueuedExternalPCM, setupExternalAudioReceiver } from './projectm-external-pcm.js';
 import { setupFboFormatIndicator } from './projectm-fbo-format.js';
 import { setupFpsGovernor } from './projectm-fps-governor.js';
-import { loadScript } from './projectm-init.js';
+import { loadScript, PROJECTM_WASM_SCRIPT } from './projectm-init.js';
 import { checkCrossOriginIsolation, checkInit, setupInitErrorHandling } from './projectm-init-errors.js';
 import { setupMeshQuality } from './projectm-mesh-quality.js';
 import { setupPerfTools } from './projectm-perf.js';
@@ -1096,7 +1096,7 @@ function tryStartRenderWorker(mcanvas) {
         const config = resolveRenderWorkerConfig();
         const handle = setupRenderWorker({
             canvas: mcanvas,
-            scriptSrc: new URL('./pm/projectm-v.030-thread.1ijs', import.meta.url).href,
+            scriptSrc: new URL(PROJECTM_WASM_SCRIPT, import.meta.url).href,
             width: mcanvas.width,
             height: mcanvas.height,
             targetFps: config.targetFps,
@@ -1148,7 +1148,7 @@ async function attemptInit() {
         }
 
         if (!Module) {
-            await loadScript("./pm/projectm-v.030-thread.1ijs", { defer: true });
+            await loadScript(PROJECTM_WASM_SCRIPT, { defer: true });
             Module = await createModule();
             globalThis.Module = Module;
         }

--- a/html/projectm-init.js
+++ b/html/projectm-init.js
@@ -1,3 +1,8 @@
+// Bump when publishing a new threaded WASM smoke build. Files must exist under ./pm/
+// after deploy (see scripts/prepare_deploy_bundle.sh and docs/DEPLOYMENT.md).
+export const PROJECTM_WASM_BUNDLE = 'projectm-v.033-thread';
+export const PROJECTM_WASM_SCRIPT = `./pm/${PROJECTM_WASM_BUNDLE}.1ijs`;
+
 export function loadScript(src, {
     documentRef = document,
     async = true,
@@ -19,7 +24,7 @@ export function loadScript(src, {
 }
 
 export async function createProjectMModule({
-    scriptSrc = './pm/projectm-v.030-thread.1ijs',
+    scriptSrc = PROJECTM_WASM_SCRIPT,
     createModuleName = 'createModule',
     windowRef = window
 } = {}) {

--- a/html/projectm.1ink
+++ b/html/projectm.1ink
@@ -1158,7 +1158,7 @@ import { setupAudioUnlock } from './projectm-audio-bootstrap.js';
 import { setupContextLossRecovery } from './projectm-context-loss.js';
 import { createSectionAudioPlayerController } from './projectm-audio-player.js';
 import { flushQueuedExternalPCM, setupExternalAudioReceiver } from './projectm-external-pcm.js';
-import { loadScript } from './projectm-init.js';
+import { loadScript, PROJECTM_WASM_SCRIPT } from './projectm-init.js';
 import { checkCrossOriginIsolation, checkInit, setupInitErrorHandling } from './projectm-init-errors.js';
 import { loadRandomApiPreset as loadRandomPresetFromApi, loadStartupApiPresets as loadStartupPresetsFromApi, updatePresetDisplay } from './projectm-presets.js';
 import { startTransitionWhenReady } from './projectm-transitions.js';
@@ -1272,7 +1272,7 @@ async function attemptInit() {
         }
 
         if (!Module) {
-            await loadScript("./pm/projectm-v.030-thread.1ijs", { defer: true });
+            await loadScript(PROJECTM_WASM_SCRIPT, { defer: true });
             Module = await createModule();
             globalThis.Module = Module;
         }

--- a/html/projectm_new.1ink
+++ b/html/projectm_new.1ink
@@ -584,7 +584,7 @@ import { setupAudioUnlock } from './projectm-audio-bootstrap.js';
 import { setupContextLossRecovery } from './projectm-context-loss.js';
 import { createSectionAudioPlayerController } from './projectm-audio-player.js';
 import { flushQueuedExternalPCM, setupExternalAudioReceiver } from './projectm-external-pcm.js';
-import { loadScript } from './projectm-init.js';
+import { loadScript, PROJECTM_WASM_SCRIPT } from './projectm-init.js';
 import { checkCrossOriginIsolation, checkInit, setupInitErrorHandling } from './projectm-init-errors.js';
 import { LOCAL_PRESET_LAST_NAME_KEY, loadLocalPresetFile, loadRandomApiPreset as loadRandomPresetFromApi, loadStartupApiPresets as loadStartupPresetsFromApi, updatePresetDisplay } from './projectm-presets.js';
 import { startTransitionWhenReady } from './projectm-transitions.js';
@@ -619,7 +619,7 @@ async function attemptInit() {
         }
 
         if (!Module) {
-            await loadScript("./pm/projectm-v.030-thread.1ijs", { defer: true });
+            await loadScript(PROJECTM_WASM_SCRIPT, { defer: true });
             Module = await createModule();
             globalThis.Module = Module;
         }

--- a/html/projectm_panel.1ink
+++ b/html/projectm_panel.1ink
@@ -346,7 +346,7 @@ import { ensureAudioRunning, setupAudioUnlock } from './projectm-audio-bootstrap
 import { setupContextLossRecovery } from './projectm-context-loss.js';
 import { createSectionAudioPlayerController } from './projectm-audio-player.js';
 import { flushQueuedExternalPCM, setupExternalAudioReceiver } from './projectm-external-pcm.js';
-import { loadScript } from './projectm-init.js';
+import { loadScript, PROJECTM_WASM_SCRIPT } from './projectm-init.js';
 import { checkCrossOriginIsolation, checkInit, setupInitErrorHandling } from './projectm-init-errors.js';
 import { loadRandomApiPreset as loadRandomPresetFromApi, loadStartupApiPresets as loadStartupPresetsFromApi, updatePresetDisplay } from './projectm-presets.js';
 import { startTransitionWhenReady } from './projectm-transitions.js';
@@ -645,7 +645,7 @@ async function attemptInit() {
         }
 
         if (!Module) {
-            await loadScript("./pm/projectm-v.030-thread.1ijs", { defer: true });
+            await loadScript(PROJECTM_WASM_SCRIPT, { defer: true });
             Module = await createModule();
             globalThis.Module = Module;
         }

--- a/html/projectm_panel2.1ink
+++ b/html/projectm_panel2.1ink
@@ -8,7 +8,7 @@
 <link rel='preconnect' href='https://storage.noahcohn.com'>
 <link rel="preload" as="image" href="./image/panel-bg.jpg" fetchpriority="high">
 <link rel="preload" as="image" href="./image/shroud.jpg">
-<link rel="preload" as="script" href="./pm/projectm-v.030-thread.1ijs">
+<link rel="preload" as="script" href="./pm/projectm-v.033-thread.1ijs">
 <title>B3HD • ProjectM</title>
 <title>1ink.us • ProjectM</title>
 
@@ -335,7 +335,7 @@ import { ensureAudioRunning, setupAudioUnlock } from './projectm-audio-bootstrap
 import { setupContextLossRecovery } from './projectm-context-loss.js';
 import { createSectionAudioPlayerController } from './projectm-audio-player.js';
 import { flushQueuedExternalPCM, setupExternalAudioReceiver } from './projectm-external-pcm.js';
-import { loadScript } from './projectm-init.js';
+import { loadScript, PROJECTM_WASM_SCRIPT } from './projectm-init.js';
 import { checkCrossOriginIsolation, checkInit, setupInitErrorHandling } from './projectm-init-errors.js';
 import { loadRandomApiPreset as loadRandomPresetFromApi, loadStartupApiPresets as loadStartupPresetsFromApi } from './projectm-presets.js';
 import { startTransitionWhenReady } from './projectm-transitions.js';
@@ -604,7 +604,7 @@ async function initProjectM() {
     }
 
     if (!Module) {
-      await loadScript('./pm/projectm-v.030-thread.1ijs', { defer: true });
+      await loadScript(PROJECTM_WASM_SCRIPT, { defer: true });
       Module = await createModule();
       globalThis.Module = Module;
     }

--- a/scripts/prepare_deploy_bundle.sh
+++ b/scripts/prepare_deploy_bundle.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Prepare WASM + iconv artifacts at the repo root (and pm/ mirror) before deploy.py.
+#
+# Usage:
+#   PROJECTM_WASM_VERSION=033 \
+#     INSTALL_DIR=install OUT_DIR=cmake-build/wasm-smoke \
+#     scripts/prepare_deploy_bundle.sh
+#
+# Then:
+#   export DEPLOY_TOKEN=...
+#   python deploy.py
+#   scripts/verify_deploy_urls.sh https://projectm.1ink.us/
+
+set -euo pipefail
+
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+INSTALL_DIR="${INSTALL_DIR:-"$PROJECT_ROOT/install"}"
+OUT_DIR="${OUT_DIR:-"$PROJECT_ROOT/cmake-build/wasm-smoke"}"
+PROJECTM_WASM_VERSION="${PROJECTM_WASM_VERSION:-033}"
+
+bundle="projectm-v.${PROJECTM_WASM_VERSION}-thread"
+src_js="$OUT_DIR/${bundle}.js"
+src_wasm="$OUT_DIR/${bundle}.wasm"
+src_worker="$OUT_DIR/${bundle}.worker.js"
+
+if [[ ! -s "$src_js" || ! -s "$src_wasm" ]]; then
+    echo "Missing smoke build outputs in $OUT_DIR — running build_wasm_smoke_wrapper.sh" >&2
+    INSTALL_DIR="$INSTALL_DIR" OUT_DIR="$OUT_DIR" \
+        bash "$PROJECT_ROOT/scripts/build_wasm_smoke_wrapper.sh"
+    # build script still emits projectm-v.030-thread.* — rename if version differs.
+    if [[ "$bundle" != "projectm-v.030-thread" && -s "$OUT_DIR/projectm-v.030-thread.js" ]]; then
+        for ext in js wasm worker.js; do
+            if [[ -f "$OUT_DIR/projectm-v.030-thread.$ext" ]]; then
+                mv -f "$OUT_DIR/projectm-v.030-thread.$ext" "$OUT_DIR/${bundle}.$ext"
+            fi
+        done
+        src_js="$OUT_DIR/${bundle}.js"
+        src_wasm="$OUT_DIR/${bundle}.wasm"
+        src_worker="$OUT_DIR/${bundle}.worker.js"
+    fi
+fi
+
+if [[ ! -s "$src_js" || ! -s "$src_wasm" ]]; then
+    echo "ERROR: expected $src_js and $src_wasm after smoke build" >&2
+    exit 1
+fi
+
+dest_js="$PROJECT_ROOT/${bundle}.js"
+dest_wasm="$PROJECT_ROOT/${bundle}.wasm"
+dest_worker="$PROJECT_ROOT/${bundle}.worker.js"
+dest_1ijs="$PROJECT_ROOT/${bundle}.1ijs"
+dest_3ijs="$PROJECT_ROOT/${bundle}.3ijs"
+dest_pm="$PROJECT_ROOT/pm"
+
+cp -f "$src_js" "$dest_js"
+cp -f "$src_wasm" "$dest_wasm"
+if [[ -s "$src_worker" ]]; then
+    cp -f "$src_worker" "$dest_worker"
+fi
+
+iconv -f UTF-8 -t UTF-16 "$dest_js" -o "$dest_1ijs"
+iconv -f UTF-8 -t UTF-32 "$dest_js" -o "$dest_3ijs"
+
+mkdir -p "$dest_pm"
+for artifact in "$dest_wasm" "$dest_1ijs" "$dest_3ijs"; do
+    cp -f "$artifact" "$dest_pm/"
+done
+if [[ -s "$dest_worker" ]]; then
+    cp -f "$dest_worker" "$dest_pm/"
+fi
+
+echo "Prepared deploy artifacts for ${bundle}:"
+ls -lh "$dest_wasm" "$dest_1ijs" "$dest_3ijs" ${dest_worker:+"$dest_worker"}
+echo "pm/ mirror:"
+ls -lh "$dest_pm/${bundle}."*

--- a/scripts/verify_deploy_urls.sh
+++ b/scripts/verify_deploy_urls.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Verify deployed WASM + host assets return 200 (not HTML 404 pages).
+#
+# Usage:
+#   scripts/verify_deploy_urls.sh [BASE_URL] [BUNDLE projectm-v.033-thread]
+#
+# Example:
+#   scripts/verify_deploy_urls.sh https://projectm.1ink.us/ projectm-v.033-thread
+
+set -euo pipefail
+
+BASE_URL="${1:-https://projectm.1ink.us/}"
+BUNDLE="${2:-projectm-v.033-thread}"
+BASE_URL="${BASE_URL%/}"
+
+paths=(
+    "${BUNDLE}.wasm"
+    "${BUNDLE}.1ijs"
+    "${BUNDLE}.3ijs"
+    "pm/${BUNDLE}.wasm"
+    "pm/${BUNDLE}.1ijs"
+    "pm/${BUNDLE}.3ijs"
+    "${BUNDLE}.worker.js"
+    "pm/${BUNDLE}.worker.js"
+    "projectm-init.js"
+    "projectm_panel2.1ink"
+    "projectm-audio-bootstrap.js"
+    "projectm-external-pcm.js"
+    "projectm-presets.js"
+)
+
+failures=0
+for rel in "${paths[@]}"; do
+    url="${BASE_URL}/${rel}"
+    status=$(curl -sS -o /dev/null -w "%{http_code}" -I "$url" || echo "000")
+    # worker.js is optional on newer Emscripten (pthread reuses the main .1ijs),
+    # but a 302/HTML redirect still indicates a broken host config.
+    if [[ "$status" == "404" && ( "$rel" == *".worker.js" ) ]]; then
+        echo "  ~ $rel -> HTTP $status (optional for pthread-main-script builds)"
+        continue
+    fi
+    if [[ "$status" != "200" ]]; then
+        echo "  ✗ $rel -> HTTP $status"
+        failures=$((failures + 1))
+    else
+        echo "  ✓ $rel -> HTTP $status"
+    fi
+done
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+    echo "$failures required URL(s) failed. A missing .1ijs/.wasm under pm/ often"
+    echo "shows in the browser as 'Unexpected token <' because Apache serves HTML 404."
+    exit 1
+fi
+
+echo "All required deploy URLs look good."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Pages load the threaded WASM bundle from `./pm/projectm-v.*-thread.1ijs`, but `deploy.py` only uploaded artifacts to the site root on `projectm.1ink.us`. After publishing 033-thread:

- `https://projectm.1ink.us/projectm-v.033-thread.1ijs` → **200**
- `https://projectm.1ink.us/pm/projectm-v.033-thread.1ijs` → **302 → HTML 404**

Browsers then throw **Unexpected token '<'** when parsing the HTML error page as JavaScript. `projectm_panel2.1ink` also 404s because shared `projectm-*.js` modules were never deployed.

032 appeared to work when those files were manually present under `pm/` from an earlier upload; 033 only landed at the root.

## Fix

- **`deploy.py`**: deploy versioned `projectm-v.*-thread.{wasm,1ijs,3ijs,worker.js}` and **mirror each WASM artifact under `pm/`**; also flatten `html/projectm-*.js`, `html/projectm-*.1ink`, and core host files into the bundle root.
- **`scripts/prepare_deploy_bundle.sh`**: build/iconv smoke artifacts into repo root + local `pm/` before deploy.
- **`scripts/verify_deploy_urls.sh`**: curl-check root + `pm/` paths after deploy.
- **`html/projectm-init.js`**: single `PROJECTM_WASM_BUNDLE` constant (`projectm-v.033-thread`); all hosts load via `PROJECTM_WASM_SCRIPT`.
- **`docs/DEPLOYMENT.md`**: updated workflow and troubleshooting table.

## Deploy after merge

```bash
PROJECTM_WASM_VERSION=033 INSTALL_DIR=install OUT_DIR=cmake-build/wasm-smoke scripts/prepare_deploy_bundle.sh
export DEPLOY_TOKEN=...
python deploy.py
scripts/verify_deploy_urls.sh https://projectm.1ink.us/ projectm-v.033-thread
```

## Custom host note

Remove duplicate script tags that load both `./projectm-v.033-thread.1ijs` (root) and `./pm/projectm-v.033-thread.1ijs` — load only from `./pm/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fef61eb6-77cc-4351-bce2-d2686de55ba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fef61eb6-77cc-4351-bce2-d2686de55ba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

