### PR TITLE
fix(web): bundle-independent FLAC player → projectM PCM bridge

### DIFF
--- a/html/flac-player/index.html
+++ b/html/flac-player/index.html
@@ -37,9 +37,20 @@ window.process = window.process || { env: {}, browser: true };
 </script>
 <script type="module">
 import { Buffer } from './vendor/buffer.bundle.mjs';
+import { installProjectMPcmBridge } from './projectm-pcm-bridge.js';
 
 globalThis.Buffer = Buffer;
 window.Buffer = Buffer;
+
+// Stream decoded audio to the projectM host via postMessage (cross-origin safe).
+// Must run BEFORE the player bundle builds its Web Audio graph so the bridge can
+// tap nodes as they connect to the destination. See projectm-pcm-bridge.js and
+// DIAGNOSIS_MOD_FLAC_PLAYER_CONNECTION.md. No-ops when opened standalone.
+try {
+  window.__projectMPcmBridge = installProjectMPcmBridge();
+} catch (error) {
+  console.debug('[projectM FLAC bridge] install failed (non-fatal):', error);
+}
 
 const bundle = document.createElement('script');
 bundle.defer = true;

--- a/html/flac-player/projectm-pcm-bridge.js
+++ b/html/flac-player/projectm-pcm-bridge.js
@@ -1,0 +1,174 @@
+// projectM PCM bridge for the in-repo FLAC player shell (html/flac-player/index.html).
+//
+// Why this exists: the FLAC player's own (externally-built, minified) bundle only
+// ships PCM to projectM over a BroadcastChannel("projectm-audio"). BroadcastChannel
+// is *same-origin only*, so when the player is opened as a cross-origin popup
+// (https://flac.1ink.us) from the projectM host, the audio never arrives — see
+// DIAGNOSIS_MOD_FLAC_PLAYER_CONNECTION.md. The host receiver
+// (html/projectm-external-pcm.js) already accepts the cross-origin-safe
+// `window.postMessage` path; this module supplies the matching sender without
+// needing to rebuild the player bundle.
+//
+// It works by patching the Web Audio graph at the prototype level *before* the
+// bundle builds its graph: whenever any node connects to `context.destination`,
+// we also tap it into a passive AnalyserNode and stream that analyser's
+// time-domain PCM to the projectM host via postMessage (opener for popups,
+// parent for iframes), plus the legacy BroadcastChannel for same-origin hosts.
+//
+// Contract (matches projectm-external-pcm.js):
+//   target.postMessage({ type: 'pcm', buffer: Float32Array, channels: 1, sampleRate }, '*')
+
+export const AUDIO_CHANNEL_NAME = 'projectm-audio';
+export const DEFAULT_FFT_SIZE = 2048;
+
+// The window the player should feed: the opener (popup case) or the embedding
+// parent (iframe case). Null when the page is standalone (nothing to feed).
+export function resolveFeedTarget(win) {
+    if (win.opener && win.opener !== win) return win.opener;
+    if (win.parent && win.parent !== win) return win.parent;
+    return null;
+}
+
+// True when this page is acting as a projectM audio feeder rather than a
+// standalone player: explicit ?projectm=1, the popup window.name the host uses,
+// or simply having an opener/parent to feed.
+export function isProjectMFeederMode(win) {
+    let params;
+    try {
+        params = new URLSearchParams(win.location.search);
+    } catch {
+        params = null;
+    }
+    if (params && params.get('projectm') === '1') return true;
+    if (win.name === 'flac-player') return true;
+    return !!resolveFeedTarget(win);
+}
+
+// Build the PCM sender. Sends over postMessage (primary, cross-origin safe) and,
+// when available, the legacy BroadcastChannel (same-origin hosts only).
+export function createPcmSender({ target, broadcastChannel = null } = {}) {
+    return function send(buffer, channels, sampleRate) {
+        if (target && typeof target.postMessage === 'function') {
+            try {
+                target.postMessage({ type: 'pcm', buffer, channels, sampleRate }, '*');
+            } catch (error) {
+                console.debug('[projectM FLAC bridge] postMessage failed (non-fatal):', error);
+            }
+        }
+        if (broadcastChannel) {
+            try {
+                broadcastChannel.postMessage({ type: 'pcm', buffer, channels });
+            } catch (error) {
+                console.debug('[projectM FLAC bridge] BroadcastChannel post failed (non-fatal):', error);
+            }
+        }
+    };
+}
+
+// Install the bridge. Injectables (windowRef, audioNodeProto, requestFrame, …)
+// exist so the wiring can be unit-tested without a real browser/Web Audio stack.
+// Returns { installed, uninstall }.
+export function installProjectMPcmBridge({
+    windowRef = typeof window !== 'undefined' ? window : undefined,
+    audioNodeProto,
+    requestFrame,
+    cancelFrame,
+    broadcastChannelCtor,
+    fftSize = DEFAULT_FFT_SIZE,
+    channelName = AUDIO_CHANNEL_NAME,
+    force = false
+} = {}) {
+    const noop = { installed: false, uninstall() {} };
+    if (!windowRef) return noop;
+    if (!force && !isProjectMFeederMode(windowRef)) return noop;
+
+    const proto = audioNodeProto
+        || (windowRef.AudioNode && windowRef.AudioNode.prototype);
+    if (!proto || typeof proto.connect !== 'function') {
+        console.debug('[projectM FLAC bridge] AudioNode.connect unavailable; bridge inactive');
+        return noop;
+    }
+
+    const raf = requestFrame
+        || (windowRef.requestAnimationFrame && windowRef.requestAnimationFrame.bind(windowRef));
+    const caf = cancelFrame
+        || (windowRef.cancelAnimationFrame && windowRef.cancelAnimationFrame.bind(windowRef));
+    if (typeof raf !== 'function') {
+        console.debug('[projectM FLAC bridge] requestAnimationFrame unavailable; bridge inactive');
+        return noop;
+    }
+
+    const BC = broadcastChannelCtor || windowRef.BroadcastChannel;
+    let broadcastChannel = null;
+    if (typeof BC === 'function') {
+        try {
+            broadcastChannel = new BC(channelName);
+        } catch (error) {
+            console.debug('[projectM FLAC bridge] BroadcastChannel unavailable:', error);
+        }
+    }
+
+    const send = createPcmSender({ target: resolveFeedTarget(windowRef), broadcastChannel });
+
+    const tapsByContext = new WeakMap();
+    const pumpHandles = [];
+
+    function startPump(context, analyser) {
+        const buf = new Float32Array(analyser.fftSize || fftSize);
+        const handle = { id: 0, active: true };
+        const tick = () => {
+            if (!handle.active) return;
+            analyser.getFloatTimeDomainData(buf);
+            // Mono time-domain samples — host duplicates to stereo and trims to
+            // its 576-sample analysis window.
+            send(buf.slice(0), 1, context.sampleRate);
+            handle.id = raf(tick);
+        };
+        handle.id = raf(tick);
+        pumpHandles.push(handle);
+    }
+
+    function ensureTap(context) {
+        if (tapsByContext.has(context)) return tapsByContext.get(context);
+        const analyser = context.createAnalyser();
+        if (typeof fftSize === 'number') {
+            try { analyser.fftSize = fftSize; } catch { /* clamp errors ignored */ }
+        }
+        tapsByContext.set(context, analyser);
+        startPump(context, analyser);
+        return analyser;
+    }
+
+    const originalConnect = proto.connect;
+    proto.connect = function patchedConnect(destination, ...rest) {
+        const result = originalConnect.apply(this, arguments);
+        try {
+            const context = this.context;
+            if (context && destination && destination === context.destination) {
+                const analyser = ensureTap(context);
+                // Passive sink: feed the source into our analyser too. The
+                // analyser is not connected onward, so playback is unaffected.
+                originalConnect.call(this, analyser);
+            }
+        } catch (error) {
+            console.debug('[projectM FLAC bridge] tap connect failed (non-fatal):', error);
+        }
+        return result;
+    };
+
+    return {
+        installed: true,
+        uninstall() {
+            proto.connect = originalConnect;
+            for (const handle of pumpHandles) {
+                handle.active = false;
+                if (typeof caf === 'function' && handle.id) caf(handle.id);
+            }
+            pumpHandles.length = 0;
+            if (broadcastChannel) {
+                try { broadcastChannel.close(); } catch { /* ignore */ }
+                broadcastChannel = null;
+            }
+        }
+    };
+}

--- a/issues/01-flac-player-pcm-bridge.md
+++ b/issues/01-flac-player-pcm-bridge.md
@@ -79,3 +79,28 @@ Or apply this change around the existing bridge:
 **Labels**: `enhancement`, `web`, `wasm`, `audio-integration`
 
 **Related work**: See full diagnosis and host-side fixes in the `diagnose-mod-flac` branch.
+
+---
+
+## Resolution (in-repo sender, no bundle rebuild required)
+
+The earlier `patches/flac-player-bridge-upgrade-to-postmessage.diff` targets the
+player's *minified external bundle*, whose source we don't have. Instead, the
+sender now lives in the in-repo player shell as a bundle-independent module:
+
+- `html/flac-player/projectm-pcm-bridge.js` — patches the Web Audio graph at the
+  prototype level: when any node connects to `context.destination`, it taps that
+  node into a passive `AnalyserNode` and streams the time-domain PCM to the host
+  via `postMessage` (opener for popups, parent for iframes) **and** the legacy
+  BroadcastChannel. Emits the documented contract
+  `{ type:'pcm', buffer:Float32Array, channels:1, sampleRate }`. No-ops when the
+  page is opened standalone (not a feeder).
+- `html/flac-player/index.html` — installs the bridge *before* loading the player
+  bundle, so the prototype patches are in place when the bundle builds its graph.
+- `tests/web/flac-pcm-bridge.test.mjs` — `node --test` coverage (feeder-mode
+  detection, sender contract, the connect→tap→pump flow, and uninstall).
+
+**Deployment dependency:** this fixes audio only if the host opens a player whose
+served `index.html` includes the bridge — i.e. deploy `html/flac-player/` to
+`flac.1ink.us` (the popup origin `projectm-core.html` opens, already on the host
+receiver's allowlist), or point `localStorage.flacPlayerUrl` at the in-repo copy.

--- a/tests/web/flac-pcm-bridge.test.mjs
+++ b/tests/web/flac-pcm-bridge.test.mjs
@@ -1,0 +1,142 @@
+// Unit tests for html/flac-player/projectm-pcm-bridge.js.
+// Run with: node --test tests/web/flac-pcm-bridge.test.mjs
+//
+// Exercises the browser-independent wiring (feeder-mode detection, sender
+// contract, and the AudioNode.connect → analyser-tap → postMessage pump) with
+// fake Web Audio objects so it runs without a browser.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    resolveFeedTarget,
+    isProjectMFeederMode,
+    createPcmSender,
+    installProjectMPcmBridge
+} from '../../html/flac-player/projectm-pcm-bridge.js';
+
+function fakeWindow({ search = '', name = '', opener = null, parent } = {}) {
+    const win = { location: { search }, name, opener };
+    win.parent = parent === undefined ? win : parent; // self by default (no iframe)
+    return win;
+}
+
+test('resolveFeedTarget prefers opener, then parent, else null', () => {
+    const opener = {};
+    const parent = {};
+    assert.equal(resolveFeedTarget(fakeWindow({ opener, parent })), opener);
+    assert.equal(resolveFeedTarget(fakeWindow({ parent })), parent);
+    assert.equal(resolveFeedTarget(fakeWindow({})), null); // parent === self
+});
+
+test('isProjectMFeederMode detects the feeder signals', () => {
+    assert.equal(isProjectMFeederMode(fakeWindow({ search: '?projectm=1' })), true);
+    assert.equal(isProjectMFeederMode(fakeWindow({ name: 'flac-player' })), true);
+    assert.equal(isProjectMFeederMode(fakeWindow({ opener: {} })), true);
+    assert.equal(isProjectMFeederMode(fakeWindow({})), false);
+});
+
+test('createPcmSender posts the documented contract to target and BroadcastChannel', () => {
+    const targetMsgs = [];
+    const bcMsgs = [];
+    const send = createPcmSender({
+        target: { postMessage: (msg, origin) => targetMsgs.push({ msg, origin }) },
+        broadcastChannel: { postMessage: (msg) => bcMsgs.push(msg) }
+    });
+    const buf = new Float32Array([0.1, -0.2]);
+    send(buf, 1, 48000);
+    assert.equal(targetMsgs.length, 1);
+    assert.deepEqual(targetMsgs[0].msg, { type: 'pcm', buffer: buf, channels: 1, sampleRate: 48000 });
+    assert.equal(targetMsgs[0].origin, '*');
+    assert.deepEqual(bcMsgs[0], { type: 'pcm', buffer: buf, channels: 1 });
+});
+
+test('createPcmSender swallows a throwing target (non-fatal)', () => {
+    const send = createPcmSender({ target: { postMessage() { throw new Error('boom'); } } });
+    assert.doesNotThrow(() => send(new Float32Array(1), 1, 44100));
+});
+
+// Build a fake Web Audio environment for the install/tap test.
+function fakeAudioEnv(waveform) {
+    const analyser = {
+        fftSize: waveform.length,
+        getFloatTimeDomainData(out) { out.set(waveform.subarray(0, out.length)); }
+    };
+    const context = {
+        sampleRate: 44100,
+        destination: { id: 'destination' },
+        createAnalyser() { return analyser; }
+    };
+    const proto = { connect(/* destination */) { this._connected = (this._connected || 0) + 1; } };
+    return { analyser, context, proto };
+}
+
+test('install taps connect-to-destination and pumps PCM to the opener once per frame', () => {
+    const waveform = new Float32Array([0.5, -0.5, 0.25, -0.25]);
+    const { context, proto } = fakeAudioEnv(waveform);
+
+    const sent = [];
+    const opener = { postMessage: (msg) => sent.push(msg) };
+    const win = fakeWindow({ opener });
+
+    // requestFrame runs the first scheduled callback exactly once (the callback
+    // reschedules itself, but we don't run the second), simulating one frame.
+    const scheduled = [];
+    const requestFrame = (cb) => { scheduled.push(cb); if (scheduled.length === 1) cb(); return scheduled.length; };
+
+    const bridge = installProjectMPcmBridge({
+        windowRef: win,
+        audioNodeProto: proto,
+        requestFrame,
+        broadcastChannelCtor: undefined,
+        fftSize: waveform.length
+    });
+    assert.equal(bridge.installed, true);
+    assert.notEqual(proto.connect, undefined);
+
+    // A source node connecting to the destination should trigger the tap+pump.
+    const source = { context };
+    proto.connect.call(source, context.destination);
+
+    // Playback connection preserved (original connect called for dest + analyser tap).
+    assert.ok(source._connected >= 1, 'original connect must still run for playback');
+    assert.equal(sent.length, 1, 'exactly one PCM frame pumped');
+    assert.equal(sent[0].type, 'pcm');
+    assert.equal(sent[0].channels, 1);
+    assert.equal(sent[0].sampleRate, 44100);
+    assert.deepEqual(Array.from(sent[0].buffer), Array.from(waveform));
+
+    bridge.uninstall();
+});
+
+test('install no-ops (and does not patch connect) when not in feeder mode', () => {
+    const { proto } = fakeAudioEnv(new Float32Array([0]));
+    const original = proto.connect;
+    const win = fakeWindow({}); // no opener/parent/flag
+    const bridge = installProjectMPcmBridge({ windowRef: win, audioNodeProto: proto, requestFrame: () => 0 });
+    assert.equal(bridge.installed, false);
+    assert.equal(proto.connect, original, 'connect must be untouched in standalone mode');
+});
+
+test('uninstall restores the original connect and stops the pump', () => {
+    const waveform = new Float32Array([1, 1]);
+    const { context, proto } = fakeAudioEnv(waveform);
+    const original = proto.connect;
+    const sent = [];
+    const win = fakeWindow({ opener: { postMessage: (m) => sent.push(m) } });
+
+    let live = null;
+    const requestFrame = (cb) => { live = cb; return 1; }; // capture, don't auto-run
+    const cancelFrame = () => { live = null; };
+
+    const bridge = installProjectMPcmBridge({
+        windowRef: win, audioNodeProto: proto, requestFrame, cancelFrame, fftSize: 2
+    });
+    proto.connect.call({ context }, context.destination); // schedules a pump (not yet run)
+    bridge.uninstall();
+    assert.equal(proto.connect, original);
+
+    // Running any leftover frame callback after uninstall must not send.
+    if (live) live();
+    assert.equal(sent.length, 0);
+});


### PR DESCRIPTION
The FLAC player only shipped PCM over BroadcastChannel("projectm-audio"), which is same-origin only — so when opened as a cross-origin popup (flac.1ink.us) from the projectM host the audio never arrived (see DIAGNOSIS_MOD_FLAC_PLAYER_CONNECTION.md). The host receiver already accepts the cross-origin-safe postMessage path; this adds the matching sender without needing the (external, minified) player bundle's source.

- html/flac-player/projectm-pcm-bridge.js: patches the Web Audio graph at the prototype level — when a node connects to context.destination it taps it into a passive AnalyserNode and streams time-domain PCM to opener/parent via postMessage plus legacy BroadcastChannel, using the documented { type:'pcm', buffer, channels:1, sampleRate } contract. No-ops standalone.
- html/flac-player/index.html: install the bridge before loading the bundle so the prototype patches are in place when it builds its graph.
- tests/web/flac-pcm-bridge.test.mjs: node --test coverage (feeder-mode detection, sender contract, connect→tap→pump flow, uninstall).
- issues/01: document the in-repo resolution + deployment dependency.


Claude-Session: https://claude.ai/code/session_01D2Mb8ZYeVGvRcsvSMA4dmt